### PR TITLE
feat: add on-screen number pad

### DIFF
--- a/frontend/lib/features/home/home_page.dart
+++ b/frontend/lib/features/home/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_starter/features/send/send_page.dart';
 import 'package:flutter_starter/l10n/app_localizations.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -24,7 +25,13 @@ class HomePage extends HookConsumerWidget {
             children: [
               FilledButton(
                   onPressed: () {}, child: Text(Loc.of(context).deposit)),
-              FilledButton(onPressed: () {}, child: Text(Loc.of(context).send)),
+              FilledButton(
+                  onPressed: () {
+                    Navigator.of(context).push(MaterialPageRoute(
+                      builder: (context) => const SendPage(),
+                    ));
+                  },
+                  child: Text(Loc.of(context).send)),
               FilledButton(
                   onPressed: () {}, child: Text(Loc.of(context).withdraw)),
             ],

--- a/frontend/lib/features/pfis/pfi_confirmation_page.dart
+++ b/frontend/lib/features/pfis/pfi_confirmation_page.dart
@@ -105,7 +105,7 @@ class PfiConfirmationPage extends HookConsumerWidget {
     }
 
     var uri = Uri.parse(
-        '${pfiService.serviceEndpoint}/credential?transaction_id=$transactionId');
+        '${pfiService.serviceEndpoint}/credential?transactionId=$transactionId');
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       // Add real error handling here...

--- a/frontend/lib/features/pfis/pfi_providers.dart
+++ b/frontend/lib/features/pfis/pfi_providers.dart
@@ -6,7 +6,7 @@ final pfisProvider = Provider<List<Pfi>>(
     Pfi(
       id: 'prototype',
       name: 'Prototype',
-      didUri: 'did:dht:3x1hbjobt577amnoeoxcenqrbjicym5mgsx6c6zszisf1igfj51y',
+      didUri: 'did:dht:74hg1efatndi8enx3e4z6c4u8ieh1xfkyay4ntg4dg1w6risu35y',
     ),
     Pfi(
       id: 'africa',

--- a/frontend/lib/features/send/send_page.dart
+++ b/frontend/lib/features/send/send_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_starter/l10n/app_localizations.dart';
+import 'package:flutter_starter/shared/number_pad.dart';
+
+class SendPage extends HookWidget {
+  const SendPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final sendAmount = useState<String>('\$0');
+
+    return Scaffold(
+        appBar: AppBar(),
+        body: SafeArea(
+          child:
+              Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    sendAmount.value,
+                    style: Theme.of(context).textTheme.displayLarge,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 40),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16.0),
+              child: NumberPad(
+                onKeyPressed: (key) {
+                  sendAmount.value = (sendAmount.value == '\$0')
+                      ? '\$$key'
+                      : '${sendAmount.value}$key';
+                },
+                onDeletePressed: () {
+                  sendAmount.value = (sendAmount.value.length > 2)
+                      ? sendAmount.value
+                          .substring(0, sendAmount.value.length - 1)
+                      : '\$0';
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20.0),
+              child: FilledButton(
+                onPressed: () {},
+                child: Text(Loc.of(context).send),
+              ),
+            ),
+          ]),
+        ));
+  }
+}

--- a/frontend/lib/shared/number_pad.dart
+++ b/frontend/lib/shared/number_pad.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class NumberPad extends HookWidget {
+  final Function(String) onKeyPressed;
+
+  const NumberPad({required this.onKeyPressed, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final pressedKey = useState<String>('');
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _buildRow(context, ['1', '2', '3'], pressedKey),
+          _buildRow(context, ['4', '5', '6'], pressedKey),
+          _buildRow(context, ['7', '8', '9'], pressedKey),
+          _buildRow(context, ['.', '0', '<'], pressedKey),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRow(
+    BuildContext context,
+    List<String> keys,
+    ValueNotifier<String> pressedKey,
+  ) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: keys.map((key) {
+        return _buildKeyButton(context, key, pressedKey);
+      }).toList(),
+    );
+  }
+
+  Widget _buildKeyButton(
+    BuildContext context,
+    String key,
+    ValueNotifier<String> pressedKey,
+  ) {
+    return Expanded(
+      child: Container(
+        margin: const EdgeInsets.all(8.0),
+        child: Center(
+          child: FilledButton(
+            onPressed: () {
+              _handleKeyPress(pressedKey, key);
+            },
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.background,
+            ),
+            child: key.isNotEmpty
+                ? Text(
+                    key,
+                    style: Theme.of(context).textTheme.displayMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          fontSize: pressedKey.value == key ? 34.0 : 20.0,
+                        ),
+                  )
+                : const Spacer(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _handleKeyPress(ValueNotifier<String> pressedKey, String key) {
+    pressedKey.value = key;
+    onKeyPressed(key);
+
+    Future.delayed(const Duration(milliseconds: 100), () {
+      pressedKey.value = '';
+    });
+  }
+}

--- a/frontend/lib/shared/number_pad.dart
+++ b/frontend/lib/shared/number_pad.dart
@@ -11,9 +11,10 @@ class NumberPad extends HookWidget {
     final pressedKey = useState<String>('');
 
     return Container(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _buildRow(context, ['1', '2', '3'], pressedKey),
           _buildRow(context, ['4', '5', '6'], pressedKey),
@@ -30,50 +31,55 @@ class NumberPad extends HookWidget {
     ValueNotifier<String> pressedKey,
   ) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: keys.map((key) {
-        return _buildKeyButton(context, key, pressedKey);
+        return NumberPadKey(title: key, onKeyPressed: onKeyPressed);
       }).toList(),
     );
   }
+}
 
-  Widget _buildKeyButton(
-    BuildContext context,
-    String key,
-    ValueNotifier<String> pressedKey,
-  ) {
-    return Expanded(
-      child: Container(
-        margin: const EdgeInsets.all(8.0),
-        child: Center(
-          child: FilledButton(
-            onPressed: () {
-              _handleKeyPress(pressedKey, key);
-            },
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.background,
+class NumberPadKey extends HookWidget {
+  final String title;
+  final Function(String) onKeyPressed;
+
+  const NumberPadKey(
+      {required this.title, required this.onKeyPressed, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const defaultSize = 24.0;
+    const selectedSize = 40.0;
+
+    final keySize = useState(defaultSize);
+
+    return Container(
+      margin: const EdgeInsets.all(8.0),
+      width: 100.0,
+      height: 50.0,
+      child: GestureDetector(
+        onTapDown: (_) => keySize.value = selectedSize,
+        onTapCancel: () => keySize.value = defaultSize,
+        onTapUp: (_) {
+          keySize.value = defaultSize;
+          onKeyPressed(title);
+        },
+        child: AnimatedDefaultTextStyle(
+          duration: const Duration(milliseconds: 100),
+          style: TextStyle(
+            fontSize: keySize.value,
+            fontWeight: FontWeight.w600,
+            color: Theme.of(context).colorScheme.onBackground,
+          ),
+          child: Center(
+            child: Text(
+              title,
+              textScaler: TextScaler.noScaling,
             ),
-            child: key.isNotEmpty
-                ? Text(
-                    key,
-                    style: Theme.of(context).textTheme.displayMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          fontSize: pressedKey.value == key ? 34.0 : 20.0,
-                        ),
-                  )
-                : const Spacer(),
           ),
         ),
       ),
     );
-  }
-
-  void _handleKeyPress(ValueNotifier<String> pressedKey, String key) {
-    pressedKey.value = key;
-    onKeyPressed(key);
-
-    Future.delayed(const Duration(milliseconds: 100), () {
-      pressedKey.value = '';
-    });
   }
 }

--- a/frontend/lib/shared/number_pad.dart
+++ b/frontend/lib/shared/number_pad.dart
@@ -3,8 +3,13 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 class NumberPad extends HookWidget {
   final Function(String) onKeyPressed;
+  final VoidCallback onDeletePressed;
 
-  const NumberPad({required this.onKeyPressed, super.key});
+  const NumberPad({
+    required this.onKeyPressed,
+    required this.onDeletePressed,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +39,11 @@ class NumberPad extends HookWidget {
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: keys.map((key) {
-        return NumberPadKey(title: key, onKeyPressed: onKeyPressed);
+        return NumberPadKey(
+          title: key,
+          onKeyPressed: onKeyPressed,
+          onDeletePressed: onDeletePressed,
+        );
       }).toList(),
     );
   }
@@ -43,9 +52,14 @@ class NumberPad extends HookWidget {
 class NumberPadKey extends HookWidget {
   final String title;
   final Function(String) onKeyPressed;
+  final VoidCallback onDeletePressed;
 
-  const NumberPadKey(
-      {required this.title, required this.onKeyPressed, super.key});
+  const NumberPadKey({
+    required this.title,
+    required this.onKeyPressed,
+    required this.onDeletePressed,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -61,9 +75,9 @@ class NumberPadKey extends HookWidget {
       child: GestureDetector(
         onTapDown: (_) => keySize.value = selectedSize,
         onTapCancel: () => keySize.value = defaultSize,
-        onTapUp: (_) {
+        onTapUp: (key) {
           keySize.value = defaultSize;
-          onKeyPressed(title);
+          (title == '<') ? onDeletePressed() : onKeyPressed(title);
         },
         child: AnimatedDefaultTextStyle(
           duration: const Duration(milliseconds: 100),


### PR DESCRIPTION
Created on-screen number pad to be used for input fields requiring number input. `SendPage` was added to show the functionality of the number pad. 

Note: the increased font size animation is made to stop only when the user lets go of the key press


https://github.com/TBD54566975/didpay/assets/125412902/84d30d86-7736-4a4a-ad10-ee67f397c9fd

https://github.com/TBD54566975/didpay/assets/125412902/e71d3ff3-60dc-4199-8900-d99270a05cf1


