### PR TITLE
feat: add account balance widget

### DIFF
--- a/frontend/lib/features/app/app_tabs.dart
+++ b/frontend/lib/features/app/app_tabs.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_starter/features/account/account_page.dart';
 import 'package:flutter_starter/features/home/home_page.dart';
+import 'package:flutter_starter/features/send/send_page.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class _TabItem {
@@ -24,6 +25,11 @@ class AppTabs extends HookConsumerWidget {
         'Home',
         const Icon(Icons.home_outlined),
         const HomePage(),
+      ),
+      _TabItem(
+        'Send',
+        const Icon(Icons.attach_money),
+        const SendPage(),
       ),
       _TabItem(
         'Account',

--- a/frontend/lib/features/home/account_balance.dart
+++ b/frontend/lib/features/home/account_balance.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_starter/l10n/app_localizations.dart';
+
+class AccountBalance extends HookWidget {
+  const AccountBalance({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+              color: Theme.of(context).colorScheme.outline, width: 2.0),
+          borderRadius: BorderRadius.circular(24.0),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              Loc.of(context).accountBalance,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+            const SizedBox(height: 10),
+            Center(
+              child: Text(
+                '\$0.00',
+                style: Theme.of(context).textTheme.displayMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Expanded(
+                  child: FilledButton(
+                      onPressed: () {}, child: Text(Loc.of(context).deposit)),
+                ),
+                const SizedBox(
+                  width: 20,
+                ),
+                Expanded(
+                  child: FilledButton(
+                      onPressed: () {}, child: Text(Loc.of(context).withdraw)),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/home/home_page.dart
+++ b/frontend/lib/features/home/home_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_starter/features/send/send_page.dart';
+import 'package:flutter_starter/features/home/account_balance.dart';
 import 'package:flutter_starter/l10n/app_localizations.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -10,33 +10,10 @@ class HomePage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(title: Text(Loc.of(context).home)),
-      body: Column(
+      body: const Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const SizedBox(height: 40),
-          Text(
-            'Balance: \$0.00 USD',
-            style: Theme.of(context).textTheme.titleLarge,
-            textAlign: TextAlign.center,
-          ),
-          const Spacer(),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              FilledButton(
-                  onPressed: () {}, child: Text(Loc.of(context).deposit)),
-              FilledButton(
-                  onPressed: () {
-                    Navigator.of(context).push(MaterialPageRoute(
-                      builder: (context) => const SendPage(),
-                    ));
-                  },
-                  child: Text(Loc.of(context).send)),
-              FilledButton(
-                  onPressed: () {}, child: Text(Loc.of(context).withdraw)),
-            ],
-          ),
-          const SizedBox(height: 40),
+          AccountBalance(),
         ],
       ),
     );

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -8,5 +8,6 @@
     "done": "Done",
     "deposit": "Deposit",
     "send": "Send",
-    "withdraw": "Withdraw"
+    "withdraw": "Withdraw",
+    "accountBalance": "Account balance"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -150,6 +150,12 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Withdraw'**
   String get withdraw;
+
+  /// No description provided for @accountBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Account balance'**
+  String get accountBalance;
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -33,4 +33,7 @@ class LocEn extends Loc {
 
   @override
   String get withdraw => 'Withdraw';
+
+  @override
+  String get accountBalance => 'Account balance';
 }

--- a/frontend/lib/shared/theme/color_scheme.dart
+++ b/frontend/lib/shared/theme/color_scheme.dart
@@ -24,12 +24,13 @@ const lightColorScheme = ColorScheme(
   onSurface: Color(0xff000000),
   surfaceVariant: Color(0xffFFE8DE),
   onSurfaceVariant: Color(0xff212121),
-  outline: Color(0xff79747E),
+  outline: Color(0xff333333),
   inverseSurface: Color(0xff313033),
   onInverseSurface: Color(0xffFFEC19),
   inversePrimary: Color(0xff000000),
   shadow: Color(0xff000000),
   surfaceTint: Color(0xffFFEC19),
+  outlineVariant: Color(0xff333333),
 );
 
 const darkColorScheme = ColorScheme(

--- a/frontend/test/features/app/app_tabs_test.dart
+++ b/frontend/test/features/app/app_tabs_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_starter/features/account/account_page.dart';
 import 'package:flutter_starter/features/app/app_tabs.dart';
 import 'package:flutter_starter/features/home/home_page.dart';
+import 'package:flutter_starter/features/send/send_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../helpers/widget_helpers.dart';
@@ -12,6 +13,16 @@ void main() {
     );
 
     expect(find.byType(HomePage), findsOneWidget);
+  });
+
+  testWidgets('should show SendPage when tapped', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      WidgetHelpers.testableWidget(child: const AppTabs()),
+    );
+
+    await tester.tap(find.text('Send'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SendPage), findsOneWidget);
   });
 
   testWidgets('should show AccountPage when tapped',

--- a/frontend/test/features/home/account_balance_test.dart
+++ b/frontend/test/features/home/account_balance_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_starter/features/home/account_balance.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/widget_helpers.dart';
+
+void main() {
+  group('AccountBalance', () {
+    testWidgets('should show account balance', (widgetTester) async {
+      await widgetTester.pumpWidget(
+        WidgetHelpers.testableWidget(child: const AccountBalance()),
+      );
+
+      expect(find.text('Account balance'), findsOneWidget);
+    });
+
+    testWidgets('should show valid account balance amount',
+        (widgetTester) async {
+      await widgetTester.pumpWidget(
+        WidgetHelpers.testableWidget(child: const AccountBalance()),
+      );
+
+      final dollarAmountPattern = RegExp(r'\$[0-9]+\.[0-9]{2}$');
+
+      expect(find.textContaining(dollarAmountPattern), findsOneWidget);
+    });
+
+    testWidgets('should show deposit button', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(child: const AccountBalance()),
+      );
+
+      expect(find.text('Deposit'), findsOneWidget);
+    });
+
+    testWidgets('should show withdraw button', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(child: const AccountBalance()),
+      );
+
+      expect(find.text('Withdraw'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Implemented account balance widget containing the balance, and buttons to deposit and withdraw. `SendPage` was moved to its own tab in `AppTabs`

![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-23 at 18 30 54](https://github.com/TBD54566975/didpay/assets/125412902/9b94d6a5-f7bf-420c-b848-f379b24a491d)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-01-23 at 18 30 41](https://github.com/TBD54566975/didpay/assets/125412902/633288ea-7836-4440-9781-799275bde90c)
