### PR TITLE
feat: add payment details page

### DIFF
--- a/frontend/lib/features/deposit/deposit_page.dart
+++ b/frontend/lib/features/deposit/deposit_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_starter/shared/currency_modal.dart';
 import 'package:flutter_starter/shared/fee_details.dart';
 import 'package:flutter_starter/shared/grid.dart';
 import 'package:flutter_starter/shared/number_pad.dart';
+import 'package:flutter_starter/shared/payment_details_page.dart';
 import 'package:flutter_starter/shared/utils/number_pad_input_validation_util.dart';
 
 // replace with actual currency list
@@ -79,7 +80,13 @@ class DepositPage extends HookWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: Grid.side),
               child: FilledButton(
-                onPressed: () {},
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => const PaymentDetailsPage(),
+                    ),
+                  );
+                },
                 child: Text(Loc.of(context).next),
               ),
             ),

--- a/frontend/lib/features/home/transaction_details_page.dart
+++ b/frontend/lib/features/home/transaction_details_page.dart
@@ -191,6 +191,7 @@ class TransactionDetailsPage extends HookWidget {
             child: Row(
               children: [
                 Expanded(
+                  flex: 2,
                   child: Text(
                     balanceLabel,
                     style: Theme.of(context).textTheme.bodyLarge,
@@ -198,6 +199,7 @@ class TransactionDetailsPage extends HookWidget {
                   ),
                 ),
                 Expanded(
+                  flex: 3,
                   child: Text(
                     '$amount USD',
                     style: Theme.of(context).textTheme.bodyLarge,

--- a/frontend/lib/features/home/transaction_details_page.dart
+++ b/frontend/lib/features/home/transaction_details_page.dart
@@ -171,9 +171,7 @@ class TransactionDetailsPage extends HookWidget {
                   flex: 1,
                   child: Text(
                     paymentLabel,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                    style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.left,
                   ),
                 ),
@@ -181,9 +179,7 @@ class TransactionDetailsPage extends HookWidget {
                   flex: 2,
                   child: Text(
                     '${txn.amount} USD',
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                    style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.right,
                   ),
                 ),
@@ -197,18 +193,14 @@ class TransactionDetailsPage extends HookWidget {
                 Expanded(
                   child: Text(
                     balanceLabel,
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                    style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.left,
                   ),
                 ),
                 Expanded(
                   child: Text(
                     '$amount USD',
-                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: Theme.of(context).colorScheme.secondary,
-                        ),
+                    style: Theme.of(context).textTheme.bodyLarge,
                     textAlign: TextAlign.right,
                   ),
                 ),

--- a/frontend/lib/features/withdraw/withdraw_page.dart
+++ b/frontend/lib/features/withdraw/withdraw_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_starter/shared/currency_modal.dart';
 import 'package:flutter_starter/shared/fee_details.dart';
 import 'package:flutter_starter/shared/grid.dart';
 import 'package:flutter_starter/shared/number_pad.dart';
+import 'package:flutter_starter/shared/payment_details_page.dart';
 import 'package:flutter_starter/shared/utils/number_pad_input_validation_util.dart';
 
 // replace with actual currency list
@@ -80,7 +81,13 @@ class WithdrawPage extends HookWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: Grid.side),
               child: FilledButton(
-                onPressed: () {},
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => const PaymentDetailsPage(),
+                    ),
+                  );
+                },
                 child: Text(Loc.of(context).next),
               ),
             ),

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -50,5 +50,17 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "serviceFeeAmount": "Service fee: {amount} {currency}",
+    "@serviceFeeAmount": {
+        "placeholders": {
+            "amount": {
+                "type": "String"
+            },
+            "currency": {
+                "type": "String"
+            }
+        }
+    },
+    "search": "Search"
 }

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -41,5 +41,14 @@
     "reject": "Reject",
     "yourRequestWasSent": "Your request was sent!",
     "yourPaymentWasSent": "Your payment was sent!",
-    "verificationComplete": "Verification complete!"
+    "verificationComplete": "Verification complete!",
+    "makeSureInfoIsCorrect": "Make sure this information is correct.",
+    "enterYourPaymentChannelDetails": "Enter your {paymentChannel} details",
+    "@enterYourPaymentChannelDetails": {
+         "placeholders": {
+            "paymentChannel": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/frontend/lib/l10n/app_en.arb
+++ b/frontend/lib/l10n/app_en.arb
@@ -62,5 +62,7 @@
             }
         }
     },
-    "search": "Search"
+    "search": "Search",
+    "serviceFeesMayApply": "Service fees may apply",
+    "selectPaymentMethod": "Select a payment method"
 }

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -300,6 +300,18 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Verification complete!'**
   String get verificationComplete;
+
+  /// No description provided for @makeSureInfoIsCorrect.
+  ///
+  /// In en, this message translates to:
+  /// **'Make sure this information is correct.'**
+  String get makeSureInfoIsCorrect;
+
+  /// No description provided for @enterYourPaymentChannelDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your {paymentChannel} details'**
+  String enterYourPaymentChannelDetails(String paymentChannel);
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -324,6 +324,18 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Search'**
   String get search;
+
+  /// No description provided for @serviceFeesMayApply.
+  ///
+  /// In en, this message translates to:
+  /// **'Service fees may apply'**
+  String get serviceFeesMayApply;
+
+  /// No description provided for @selectPaymentMethod.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a payment method'**
+  String get selectPaymentMethod;
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/frontend/lib/l10n/app_localizations.dart
+++ b/frontend/lib/l10n/app_localizations.dart
@@ -312,6 +312,18 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Enter your {paymentChannel} details'**
   String enterYourPaymentChannelDetails(String paymentChannel);
+
+  /// No description provided for @serviceFeeAmount.
+  ///
+  /// In en, this message translates to:
+  /// **'Service fee: {amount} {currency}'**
+  String serviceFeeAmount(String amount, String currency);
+
+  /// No description provided for @search.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get search;
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -126,4 +126,10 @@ class LocEn extends Loc {
 
   @override
   String get search => 'Search';
+
+  @override
+  String get serviceFeesMayApply => 'Service fees may apply';
+
+  @override
+  String get selectPaymentMethod => 'Select a payment method';
 }

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -118,4 +118,12 @@ class LocEn extends Loc {
   String enterYourPaymentChannelDetails(String paymentChannel) {
     return 'Enter your $paymentChannel details';
   }
+
+  @override
+  String serviceFeeAmount(String amount, String currency) {
+    return 'Service fee: $amount $currency';
+  }
+
+  @override
+  String get search => 'Search';
 }

--- a/frontend/lib/l10n/app_localizations_en.dart
+++ b/frontend/lib/l10n/app_localizations_en.dart
@@ -110,4 +110,12 @@ class LocEn extends Loc {
 
   @override
   String get verificationComplete => 'Verification complete!';
+
+  @override
+  String get makeSureInfoIsCorrect => 'Make sure this information is correct.';
+
+  @override
+  String enterYourPaymentChannelDetails(String paymentChannel) {
+    return 'Enter your $paymentChannel details';
+  }
 }

--- a/frontend/lib/shared/json_schema_form.dart
+++ b/frontend/lib/shared/json_schema_form.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'dart:convert';
 
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_starter/l10n/app_localizations.dart';
+import 'package:flutter_starter/shared/grid.dart';
 
 class JsonSchemaForm extends HookWidget {
   final String schema;
@@ -20,7 +22,10 @@ class JsonSchemaForm extends HookWidget {
       formFields.add(TextFormField(
         decoration: InputDecoration(
           labelText: value['title'] ?? key,
-          hintText: value['description'],
+          labelStyle: TextStyle(
+            color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+          border: InputBorder.none,
         ),
         validator: (value) => _validateField(key, value, jsonSchema),
         onSaved: (value) => formData[key] = value ?? '',
@@ -29,22 +34,35 @@ class JsonSchemaForm extends HookWidget {
 
     return Form(
       key: _formKey,
-      child: SingleChildScrollView(
-        child: Column(
-          children: [
-            ...formFields,
-            FilledButton(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              physics: const BouncingScrollPhysics(),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: Grid.side,
+                ),
+                child: Column(
+                  children: formFields,
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: Grid.side),
+            child: FilledButton(
               onPressed: () {
                 if (_formKey.currentState!.validate()) {
                   _formKey.currentState!.save();
-
                   onSubmit(formData);
                 }
               },
-              child: const Text('Submit'),
+              child: Text(Loc.of(context).next),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -63,6 +81,13 @@ class JsonSchemaForm extends HookWidget {
       var minLength = jsonSchema['properties'][key]['minLength'] as int?;
       var maxLength = jsonSchema['properties'][key]['maxLength'] as int?;
       var pattern = jsonSchema['properties'][key]['pattern'] as String?;
+
+      if (minLength != null &&
+          maxLength != null &&
+          minLength == maxLength &&
+          value.length != minLength) {
+        return 'Must be exactly $minLength characters';
+      }
 
       if (minLength != null && value.length < minLength) {
         return 'Minimum length is $minLength characters';

--- a/frontend/lib/shared/json_schema_form.dart
+++ b/frontend/lib/shared/json_schema_form.dart
@@ -83,7 +83,6 @@ class JsonSchemaForm extends HookWidget {
       var pattern = jsonSchema['properties'][key]['pattern'] as String?;
 
       if (minLength != null &&
-          maxLength != null &&
           minLength == maxLength &&
           value.length != minLength) {
         return 'Must be exactly $minLength characters';

--- a/frontend/lib/shared/payment_details_page.dart
+++ b/frontend/lib/shared/payment_details_page.dart
@@ -14,8 +14,9 @@ class PaymentDetailsPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final paymentMethods = ref.watch(paymentMethodProvider);
 
-    final paymentTypes =
-        paymentMethods?.map((method) => method.kind.split('_').first).toSet();
+    final paymentTypes = paymentMethods
+        ?.map((method) => method.kind.split('_').firstOrNull)
+        .toSet();
 
     final selectedPaymentMethod = useState(paymentMethods?.firstOrNull);
     final selectedPaymentType = useState(paymentTypes?.firstOrNull);
@@ -130,7 +131,8 @@ class PaymentDetailsPage extends HookConsumerWidget {
     ValueNotifier<PaymentMethod?> selectedPaymentMethod,
     List<PaymentMethod>? availablePaymentMethods,
   ) {
-    final paymentSubtype = selectedPaymentMethod.value?.kind.split('_').last;
+    final paymentSubtype =
+        selectedPaymentMethod.value?.kind.split('_').lastOrNull;
     final fee = (double.tryParse(selectedPaymentMethod.value?.fee ?? '0.00')
             ?.toStringAsFixed(2) ??
         '0.00');

--- a/frontend/lib/shared/payment_details_page.dart
+++ b/frontend/lib/shared/payment_details_page.dart
@@ -170,7 +170,7 @@ class PaymentDetailsPage extends HookConsumerWidget {
     ValueNotifier<PaymentMethod?> selectedPaymentMethod,
   ) {
     return selectedPaymentMethod.value == null
-        ? Container()
+        ? _buildDisabledButton(context)
         : Expanded(
             child: JsonSchemaForm(
               schema: selectedPaymentMethod.value!.requiredPaymentDetails,
@@ -179,5 +179,23 @@ class PaymentDetailsPage extends HookConsumerWidget {
               },
             ),
           );
+  }
+
+  Widget _buildDisabledButton(BuildContext context) {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(child: Container()),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: Grid.side),
+            child: FilledButton(
+              onPressed: null,
+              child: Text(Loc.of(context).next),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/frontend/lib/shared/payment_details_page.dart
+++ b/frontend/lib/shared/payment_details_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_starter/l10n/app_localizations.dart';
 import 'package:flutter_starter/shared/grid.dart';
 import 'package:flutter_starter/shared/json_schema_form.dart';
 import 'package:flutter_starter/shared/payment_method.dart';
-import 'package:flutter_starter/shared/payment_methods_page.dart';
+import 'package:flutter_starter/shared/search_payment_methods_page.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class PaymentDetailsPage extends HookConsumerWidget {
@@ -48,10 +48,8 @@ class PaymentDetailsPage extends HookConsumerWidget {
                 selectedPaymentType.value.toLowerCase(),
               ),
             ),
-            const SizedBox(
-              height: Grid.xs,
-            ),
-            _buildPaymentProvider(
+            const SizedBox(height: Grid.xs),
+            _buildPaymentMethodTile(
               context,
               selectedPaymentMethod,
               typeToPaymentMethods[selectedPaymentType.value] ?? [],
@@ -60,43 +58,12 @@ class PaymentDetailsPage extends HookConsumerWidget {
               child: JsonSchemaForm(
                   schema: selectedPaymentMethod.value.requiredPaymentDetails,
                   onSubmit: (formData) {
-                    print('Form data submitted: $formData');
+                    // TODO: save payment details here
                   }),
             ),
           ],
         ),
       ),
-    );
-  }
-
-  Widget _buildPaymentProvider(
-    BuildContext context,
-    ValueNotifier<PaymentMethod> selectedPaymentMethod,
-    List<PaymentMethod> paymentMethods,
-  ) {
-    return ListTile(
-      title: Text(
-        selectedPaymentMethod.value.kind,
-        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: Theme.of(context).colorScheme.primary,
-            ),
-      ),
-      subtitle: Text(
-        'Service fee',
-        style: Theme.of(context).textTheme.bodySmall,
-      ),
-      contentPadding: const EdgeInsets.symmetric(horizontal: Grid.side),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => PaymentMethodsPage(
-              selectedPaymentMethod: selectedPaymentMethod,
-              paymentMethods: paymentMethods,
-            ),
-          ),
-        );
-      },
     );
   }
 
@@ -147,15 +114,50 @@ class PaymentDetailsPage extends HookConsumerWidget {
             (Set<MaterialState> _) {
               return BorderSide(
                 color: Theme.of(context).colorScheme.secondaryContainer,
-                width: 3.0,
+                width: Grid.half,
               );
             },
           ),
           shape: MaterialStateProperty.all(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14.0)),
+            RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(Grid.xs)),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildPaymentMethodTile(
+    BuildContext context,
+    ValueNotifier<PaymentMethod> selectedPaymentMethod,
+    List<PaymentMethod> paymentMethods,
+  ) {
+    final paymentSubtype = selectedPaymentMethod.value.kind.split('_').last;
+    final fee = selectedPaymentMethod.value.fee ?? '0.0';
+
+    return ListTile(
+      title: Text(
+        paymentSubtype,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+      ),
+      subtitle: Text(
+        Loc.of(context).serviceFeeAmount(fee, 'USD'),
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: Grid.side),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => SearchPaymentMethodsPage(
+              selectedPaymentMethod: selectedPaymentMethod,
+              paymentMethods: paymentMethods,
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/frontend/lib/shared/payment_details_page.dart
+++ b/frontend/lib/shared/payment_details_page.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_starter/l10n/app_localizations.dart';
+import 'package:flutter_starter/shared/grid.dart';
+import 'package:flutter_starter/shared/json_schema_form.dart';
+import 'package:flutter_starter/shared/payment_method.dart';
+import 'package:flutter_starter/shared/payment_methods_page.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class PaymentDetailsPage extends HookConsumerWidget {
+  const PaymentDetailsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final paymentMethods = ref.watch(paymentMethodProvider);
+
+    final selectedPaymentMethod = useState<PaymentMethod>(paymentMethods.first);
+    final selectedPaymentType =
+        useState<String>(paymentMethods.first.kind.split('_').first);
+
+    final paymentTypes =
+        paymentMethods.map((method) => method.kind.split('_').first).toSet();
+
+    final Map<String, List<PaymentMethod>> typeToPaymentMethods = {};
+
+    for (var method in paymentMethods) {
+      var prefix = method.kind.split('_').first;
+      (typeToPaymentMethods.putIfAbsent(prefix, () => [])..add(method));
+    }
+
+    return Scaffold(
+      appBar: AppBar(),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (paymentTypes.length > 1)
+              _buildPaymentTypeSegments(
+                context,
+                paymentTypes,
+                selectedPaymentType,
+                selectedPaymentMethod,
+                typeToPaymentMethods,
+              ),
+            _buildHeader(
+              context,
+              Loc.of(context).enterYourPaymentChannelDetails(
+                selectedPaymentType.value.toLowerCase(),
+              ),
+            ),
+            const SizedBox(
+              height: Grid.xs,
+            ),
+            _buildPaymentProvider(
+              context,
+              selectedPaymentMethod,
+              typeToPaymentMethods[selectedPaymentType.value] ?? [],
+            ),
+            Expanded(
+              child: JsonSchemaForm(
+                  schema: selectedPaymentMethod.value.requiredPaymentDetails,
+                  onSubmit: (formData) {
+                    print('Form data submitted: $formData');
+                  }),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPaymentProvider(
+    BuildContext context,
+    ValueNotifier<PaymentMethod> selectedPaymentMethod,
+    List<PaymentMethod> paymentMethods,
+  ) {
+    return ListTile(
+      title: Text(
+        selectedPaymentMethod.value.kind,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+      ),
+      subtitle: Text(
+        'Service fee',
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: Grid.side),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => PaymentMethodsPage(
+              selectedPaymentMethod: selectedPaymentMethod,
+              paymentMethods: paymentMethods,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildPaymentTypeSegments(
+    BuildContext context,
+    Set<String> paymentTypes,
+    ValueNotifier<String> selectedPaymentType,
+    ValueNotifier<PaymentMethod> selectedPaymentMethod,
+    Map<String, List<PaymentMethod>> typeToPaymentMethods,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: Grid.side,
+        right: Grid.side,
+      ),
+      child: SegmentedButton<String>(
+        segments: paymentTypes
+            .map(
+              (segment) => ButtonSegment<String>(
+                value: segment,
+                label: Text(
+                  segment,
+                  style: TextStyle(
+                    color: selectedPaymentType.value == segment
+                        ? Theme.of(context).colorScheme.onSurface
+                        : Theme.of(context).disabledColor,
+                  ),
+                ),
+              ),
+            )
+            .toList(),
+        selected: {selectedPaymentType.value},
+        showSelectedIcon: false,
+        onSelectionChanged: (value) {
+          selectedPaymentType.value = value.first;
+          selectedPaymentMethod.value =
+              typeToPaymentMethods[value.first]!.first;
+        },
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.resolveWith<Color>(
+            (Set<MaterialState> states) {
+              return states.contains(MaterialState.selected)
+                  ? Theme.of(context).colorScheme.surface
+                  : Theme.of(context).colorScheme.secondaryContainer;
+            },
+          ),
+          side: MaterialStateProperty.resolveWith<BorderSide>(
+            (Set<MaterialState> _) {
+              return BorderSide(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+                width: 3.0,
+              );
+            },
+          ),
+          shape: MaterialStateProperty.all(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14.0)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, String title) {
+    return Padding(
+      padding:
+          const EdgeInsets.symmetric(horizontal: Grid.side, vertical: Grid.xs),
+      child: Column(
+        children: [
+          Align(
+            alignment: Alignment.topLeft,
+            child: Text(
+              title,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ),
+          const SizedBox(height: Grid.xs),
+          Align(
+            alignment: Alignment.topLeft,
+            child: Text(
+              Loc.of(context).makeSureInfoIsCorrect,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/shared/payment_method.dart
+++ b/frontend/lib/shared/payment_method.dart
@@ -37,16 +37,16 @@ final _defaultList = [
     kind: 'MOMO_MPESA',
     requiredPaymentDetails: momoSchema,
   ),
-  PaymentMethod(
-    kind: 'WALLET_BTC ADDRESS',
-    requiredPaymentDetails: walletSchema,
-    fee: '5.0',
-  ),
-  PaymentMethod(
-    kind: 'WALLET_USDC ADDRESS',
-    requiredPaymentDetails: walletSchema,
-    fee: '2.0',
-  ),
+  // PaymentMethod(
+  //   kind: 'WALLET_BTC ADDRESS',
+  //   requiredPaymentDetails: walletSchema,
+  //   fee: '5.0',
+  // ),
+  // PaymentMethod(
+  //   kind: 'WALLET_USDC ADDRESS',
+  //   requiredPaymentDetails: walletSchema,
+  //   fee: '2.0',
+  // ),
 ];
 
 final paymentMethodProvider = StateProvider<List<PaymentMethod>>((ref) {

--- a/frontend/lib/shared/payment_method.dart
+++ b/frontend/lib/shared/payment_method.dart
@@ -1,0 +1,103 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+// TODO: remove this file when FTL generated types are available
+class PaymentMethod {
+  final String kind;
+  final String requiredPaymentDetails;
+  final String? fee;
+
+  PaymentMethod({
+    required this.kind,
+    required this.requiredPaymentDetails,
+    this.fee,
+  });
+}
+
+final paymentMethodProvider = StateProvider<List<PaymentMethod>>((ref) {
+  return [
+    PaymentMethod(
+      kind: 'BTC_ADDRESS WALLET',
+      requiredPaymentDetails: walletSchema,
+    ),
+    PaymentMethod(
+      kind: 'MOMO_MTN',
+      requiredPaymentDetails: momoSchema,
+    ),
+    PaymentMethod(
+      kind: 'MOMO_MPESA',
+      requiredPaymentDetails: momoSchema,
+    ),
+    PaymentMethod(
+      kind: 'BANK_Access Bank',
+      requiredPaymentDetails: bankSchema,
+      fee: '10.0',
+    ),
+  ];
+});
+
+const String bankSchema = '''
+  {
+    "properties": {
+      "accountNumber": {
+        "type": "string",
+        "title": "Account Number",
+        "description": "Bank account number of the recipient",
+        "minLength": 10,
+        "maxLength": 10
+      },
+      "reason": {
+        "title": "Reason for sending",
+        "description": "To abide by the travel rules and financial reporting requirements, the reason for sending money",
+        "type": "string"
+      }
+    },
+    "required": [
+      "accountNumber",
+      "reason"
+    ],
+    "additionalProperties": false
+  }''';
+
+const String momoSchema = '''
+  {
+    "properties": {
+      "accountNumber": {
+        "type": "string",
+        "title": "Phone Number",
+        "description": "Mobile money account number of the recipient",
+        "minLength": 12,
+        "maxLength": 12
+      },
+      "reason": {
+        "title": "Reason for sending",
+        "description": "To abide by the travel rules and financial reporting requirements, the reason for sending money",
+        "type": "string"
+      }
+    },
+    "required": [
+      "accountNumber",
+      "reason"
+    ],
+    "additionalProperties": false
+  }''';
+
+const String walletSchema = '''
+  {
+    "properties": {
+      "walletAddress": {
+        "type": "string",
+        "description": "Your wallet address",
+        "title": "BTC Address"
+      },
+      "reason": {
+        "title": "Reason for sending",
+        "description": "To abide by the travel rules and financial reporting requirements, the reason for sending money",
+        "type": "string"
+      }
+    },
+    "required": [
+      "walletAddress",
+      "reason"
+    ],
+    "additionalProperties": false
+  }''';

--- a/frontend/lib/shared/payment_method.dart
+++ b/frontend/lib/shared/payment_method.dart
@@ -13,26 +13,44 @@ class PaymentMethod {
   });
 }
 
+final _defaultList = [
+  PaymentMethod(
+    kind: 'BANK_ACCESS BANK',
+    requiredPaymentDetails: bankSchema,
+    fee: '9.0',
+  ),
+  PaymentMethod(
+    kind: 'BANK_GT BANK',
+    requiredPaymentDetails: bankSchema,
+    fee: '8.0',
+  ),
+  PaymentMethod(
+    kind: 'BANK_UNITED BANK FOR AFRICA',
+    requiredPaymentDetails: bankSchema,
+    fee: '10.0',
+  ),
+  PaymentMethod(
+    kind: 'MOMO_MTN',
+    requiredPaymentDetails: momoSchema,
+  ),
+  PaymentMethod(
+    kind: 'MOMO_MPESA',
+    requiredPaymentDetails: momoSchema,
+  ),
+  PaymentMethod(
+    kind: 'WALLET_BTC ADDRESS',
+    requiredPaymentDetails: walletSchema,
+    fee: '5.0',
+  ),
+  PaymentMethod(
+    kind: 'WALLET_USDC ADDRESS',
+    requiredPaymentDetails: walletSchema,
+    fee: '2.0',
+  ),
+];
+
 final paymentMethodProvider = StateProvider<List<PaymentMethod>>((ref) {
-  return [
-    PaymentMethod(
-      kind: 'BTC_ADDRESS WALLET',
-      requiredPaymentDetails: walletSchema,
-    ),
-    PaymentMethod(
-      kind: 'MOMO_MTN',
-      requiredPaymentDetails: momoSchema,
-    ),
-    PaymentMethod(
-      kind: 'MOMO_MPESA',
-      requiredPaymentDetails: momoSchema,
-    ),
-    PaymentMethod(
-      kind: 'BANK_Access Bank',
-      requiredPaymentDetails: bankSchema,
-      fee: '10.0',
-    ),
-  ];
+  return _defaultList;
 });
 
 const String bankSchema = '''
@@ -40,7 +58,7 @@ const String bankSchema = '''
     "properties": {
       "accountNumber": {
         "type": "string",
-        "title": "Account Number",
+        "title": "Account number",
         "description": "Bank account number of the recipient",
         "minLength": 10,
         "maxLength": 10
@@ -63,7 +81,7 @@ const String momoSchema = '''
     "properties": {
       "accountNumber": {
         "type": "string",
-        "title": "Phone Number",
+        "title": "Phone number",
         "description": "Mobile money account number of the recipient",
         "minLength": 12,
         "maxLength": 12
@@ -87,7 +105,7 @@ const String walletSchema = '''
       "walletAddress": {
         "type": "string",
         "description": "Your wallet address",
-        "title": "BTC Address"
+        "title": "Wallet address"
       },
       "reason": {
         "title": "Reason for sending",

--- a/frontend/lib/shared/payment_method.dart
+++ b/frontend/lib/shared/payment_method.dart
@@ -49,7 +49,7 @@ final _defaultList = [
   // ),
 ];
 
-final paymentMethodProvider = StateProvider<List<PaymentMethod>>((ref) {
+final paymentMethodProvider = StateProvider<List<PaymentMethod>?>((ref) {
   return _defaultList;
 });
 

--- a/frontend/lib/shared/payment_methods_page.dart
+++ b/frontend/lib/shared/payment_methods_page.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_starter/shared/grid.dart';
+import 'package:flutter_starter/shared/payment_method.dart';
+
+class PaymentMethodsPage extends HookWidget {
+  final _formKey = GlobalKey<FormState>();
+  final ValueNotifier<PaymentMethod> selectedPaymentMethod;
+  final List<PaymentMethod> paymentMethods;
+
+  PaymentMethodsPage({
+    required this.selectedPaymentMethod,
+    required this.paymentMethods,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final searchText = useState<String>('');
+
+    return Scaffold(
+      appBar: AppBar(scrolledUnderElevation: 0),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: Grid.sm),
+                    child: TextFormField(
+                      decoration: InputDecoration(
+                        labelText: 'Search',
+                        prefixIcon: const Icon(Icons.search),
+                      ),
+                      onChanged: (value) => searchText.value = value,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: _buildList(
+                context,
+                selectedPaymentMethod,
+                searchText,
+                paymentMethods,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(
+    BuildContext context,
+    ValueNotifier<PaymentMethod> selectedPaymentMethod,
+    ValueNotifier<String> searchText,
+    List<PaymentMethod> paymentMethods,
+  ) {
+    final filteredPaymentMethods = paymentMethods
+        .where((entry) =>
+            entry.kind.toLowerCase().contains(searchText.value.toLowerCase()))
+        .toList();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: Grid.sm),
+      child: ListView.builder(
+        itemBuilder: (context, index) {
+          final currentPaymentMethod = filteredPaymentMethods.elementAt(index);
+
+          final paymentProvider = currentPaymentMethod.kind.split('_').last;
+
+          return ListTile(
+            visualDensity: VisualDensity.compact,
+            selected: selectedPaymentMethod.value == currentPaymentMethod,
+            title: Text(paymentProvider),
+            subtitle: Text(
+              'Service fee',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            trailing: selectedPaymentMethod.value == currentPaymentMethod
+                ? const Icon(Icons.check)
+                : null,
+            onTap: () {
+              selectedPaymentMethod.value = currentPaymentMethod;
+              print('Selected payment method: ${currentPaymentMethod.kind}');
+              Navigator.of(context).pop();
+            },
+          );
+        },
+        itemCount: filteredPaymentMethods.length,
+      ),
+    );
+  }
+}

--- a/frontend/lib/shared/search_payment_methods_page.dart
+++ b/frontend/lib/shared/search_payment_methods_page.dart
@@ -6,8 +6,8 @@ import 'package:flutter_starter/shared/payment_method.dart';
 
 class SearchPaymentMethodsPage extends HookWidget {
   final _formKey = GlobalKey<FormState>();
-  final ValueNotifier<PaymentMethod> selectedPaymentMethod;
-  final List<PaymentMethod> paymentMethods;
+  final ValueNotifier<PaymentMethod?> selectedPaymentMethod;
+  final List<PaymentMethod>? paymentMethods;
 
   SearchPaymentMethodsPage({
     required this.selectedPaymentMethod,
@@ -17,41 +17,42 @@ class SearchPaymentMethodsPage extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final searchText = useState<String>('');
+    final searchText = useState('');
 
     return Scaffold(
       appBar: AppBar(scrolledUnderElevation: 0),
       body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Form(
-              key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextFormField(
-                    decoration: InputDecoration(
-                      labelText: Loc.of(context).search,
-                      prefixIcon: const Icon(Icons.search),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: Grid.side,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Grid.side),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Form(
+                key: _formKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextFormField(
+                      decoration: InputDecoration(
+                        labelText: Loc.of(context).search,
+                        prefixIcon: const Icon(Icons.search),
                       ),
+                      onChanged: (value) => searchText.value = value,
                     ),
-                    onChanged: (value) => searchText.value = value,
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            Expanded(
-              child: _buildList(
-                context,
-                selectedPaymentMethod,
-                searchText,
-                paymentMethods,
+              const SizedBox(height: Grid.xs),
+              Expanded(
+                child: _buildList(
+                  context,
+                  selectedPaymentMethod,
+                  searchText,
+                  paymentMethods,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -59,25 +60,28 @@ class SearchPaymentMethodsPage extends HookWidget {
 
   Widget _buildList(
     BuildContext context,
-    ValueNotifier<PaymentMethod> selectedPaymentMethod,
+    ValueNotifier<PaymentMethod?> selectedPaymentMethod,
     ValueNotifier<String> searchText,
-    List<PaymentMethod> paymentMethods,
+    List<PaymentMethod>? paymentMethods,
   ) {
     final filteredPaymentMethods = paymentMethods
-        .where((entry) =>
+        ?.where((entry) =>
             entry.kind.toLowerCase().contains(searchText.value.toLowerCase()))
         .toList();
 
     return ListView.builder(
       itemBuilder: (context, index) {
-        final currentPaymentMethod = filteredPaymentMethods.elementAt(index);
-        final paymentSubtype = currentPaymentMethod.kind.split('_').last;
-        final fee = currentPaymentMethod.fee ?? '0.0';
+        final currentPaymentMethod =
+            filteredPaymentMethods?.elementAtOrNull(index);
+        final paymentSubtype = currentPaymentMethod?.kind.split('_').last;
+        final fee = (double.tryParse(currentPaymentMethod?.fee ?? '0.00')
+                ?.toStringAsFixed(2) ??
+            '0.00');
 
         return ListTile(
           visualDensity: VisualDensity.compact,
           selected: selectedPaymentMethod.value == currentPaymentMethod,
-          title: Text(paymentSubtype),
+          title: Text(paymentSubtype ?? ''),
           subtitle: Text(
             Loc.of(context).serviceFeeAmount(fee, 'USD'),
             style: Theme.of(context).textTheme.bodySmall,
@@ -85,14 +89,14 @@ class SearchPaymentMethodsPage extends HookWidget {
           trailing: selectedPaymentMethod.value == currentPaymentMethod
               ? const Icon(Icons.check)
               : null,
-          contentPadding: const EdgeInsets.symmetric(horizontal: Grid.side),
           onTap: () {
-            selectedPaymentMethod.value = currentPaymentMethod;
+            selectedPaymentMethod.value =
+                currentPaymentMethod ?? selectedPaymentMethod.value;
             Navigator.of(context).pop();
           },
         );
       },
-      itemCount: filteredPaymentMethods.length,
+      itemCount: filteredPaymentMethods?.length,
     );
   }
 }

--- a/frontend/lib/shared/search_payment_methods_page.dart
+++ b/frontend/lib/shared/search_payment_methods_page.dart
@@ -73,7 +73,7 @@ class SearchPaymentMethodsPage extends HookWidget {
       itemBuilder: (context, index) {
         final currentPaymentMethod =
             filteredPaymentMethods?.elementAtOrNull(index);
-        final paymentSubtype = currentPaymentMethod?.kind.split('_').lastOrNull;
+        final paymentName = currentPaymentMethod?.kind.split('_').lastOrNull;
         final fee = (double.tryParse(currentPaymentMethod?.fee ?? '0.00')
                 ?.toStringAsFixed(2) ??
             '0.00');
@@ -81,7 +81,7 @@ class SearchPaymentMethodsPage extends HookWidget {
         return ListTile(
           visualDensity: VisualDensity.compact,
           selected: selectedPaymentMethod.value == currentPaymentMethod,
-          title: Text(paymentSubtype ?? ''),
+          title: Text(paymentName ?? ''),
           subtitle: Text(
             Loc.of(context).serviceFeeAmount(fee, 'USD'),
             style: Theme.of(context).textTheme.bodySmall,

--- a/frontend/lib/shared/search_payment_methods_page.dart
+++ b/frontend/lib/shared/search_payment_methods_page.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_starter/l10n/app_localizations.dart';
 import 'package:flutter_starter/shared/grid.dart';
 import 'package:flutter_starter/shared/payment_method.dart';
 
-class PaymentMethodsPage extends HookWidget {
+class SearchPaymentMethodsPage extends HookWidget {
   final _formKey = GlobalKey<FormState>();
   final ValueNotifier<PaymentMethod> selectedPaymentMethod;
   final List<PaymentMethod> paymentMethods;
 
-  PaymentMethodsPage({
+  SearchPaymentMethodsPage({
     required this.selectedPaymentMethod,
     required this.paymentMethods,
     super.key,
@@ -29,15 +30,15 @@ class PaymentMethodsPage extends HookWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: Grid.sm),
-                    child: TextFormField(
-                      decoration: InputDecoration(
-                        labelText: 'Search',
-                        prefixIcon: const Icon(Icons.search),
+                  TextFormField(
+                    decoration: InputDecoration(
+                      labelText: Loc.of(context).search,
+                      prefixIcon: const Icon(Icons.search),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: Grid.side,
                       ),
-                      onChanged: (value) => searchText.value = value,
                     ),
+                    onChanged: (value) => searchText.value = value,
                   ),
                 ],
               ),
@@ -67,34 +68,31 @@ class PaymentMethodsPage extends HookWidget {
             entry.kind.toLowerCase().contains(searchText.value.toLowerCase()))
         .toList();
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: Grid.sm),
-      child: ListView.builder(
-        itemBuilder: (context, index) {
-          final currentPaymentMethod = filteredPaymentMethods.elementAt(index);
+    return ListView.builder(
+      itemBuilder: (context, index) {
+        final currentPaymentMethod = filteredPaymentMethods.elementAt(index);
+        final paymentSubtype = currentPaymentMethod.kind.split('_').last;
+        final fee = currentPaymentMethod.fee ?? '0.0';
 
-          final paymentProvider = currentPaymentMethod.kind.split('_').last;
-
-          return ListTile(
-            visualDensity: VisualDensity.compact,
-            selected: selectedPaymentMethod.value == currentPaymentMethod,
-            title: Text(paymentProvider),
-            subtitle: Text(
-              'Service fee',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            trailing: selectedPaymentMethod.value == currentPaymentMethod
-                ? const Icon(Icons.check)
-                : null,
-            onTap: () {
-              selectedPaymentMethod.value = currentPaymentMethod;
-              print('Selected payment method: ${currentPaymentMethod.kind}');
-              Navigator.of(context).pop();
-            },
-          );
-        },
-        itemCount: filteredPaymentMethods.length,
-      ),
+        return ListTile(
+          visualDensity: VisualDensity.compact,
+          selected: selectedPaymentMethod.value == currentPaymentMethod,
+          title: Text(paymentSubtype),
+          subtitle: Text(
+            Loc.of(context).serviceFeeAmount(fee, 'USD'),
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          trailing: selectedPaymentMethod.value == currentPaymentMethod
+              ? const Icon(Icons.check)
+              : null,
+          contentPadding: const EdgeInsets.symmetric(horizontal: Grid.side),
+          onTap: () {
+            selectedPaymentMethod.value = currentPaymentMethod;
+            Navigator.of(context).pop();
+          },
+        );
+      },
+      itemCount: filteredPaymentMethods.length,
     );
   }
 }

--- a/frontend/lib/shared/search_payment_methods_page.dart
+++ b/frontend/lib/shared/search_payment_methods_page.dart
@@ -73,7 +73,7 @@ class SearchPaymentMethodsPage extends HookWidget {
       itemBuilder: (context, index) {
         final currentPaymentMethod =
             filteredPaymentMethods?.elementAtOrNull(index);
-        final paymentSubtype = currentPaymentMethod?.kind.split('_').last;
+        final paymentSubtype = currentPaymentMethod?.kind.split('_').lastOrNull;
         final fee = (double.tryParse(currentPaymentMethod?.fee ?? '0.00')
                 ?.toStringAsFixed(2) ??
             '0.00');

--- a/frontend/lib/shared/theme/theme.dart
+++ b/frontend/lib/shared/theme/theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_starter/shared/grid.dart';
 import 'package:flutter_starter/shared/theme/color_scheme.dart';
 import 'package:flutter_starter/shared/theme/text_theme.dart';
 
@@ -6,10 +7,56 @@ ThemeData lightTheme(BuildContext context) => ThemeData(
       useMaterial3: true,
       colorScheme: lightColorScheme,
       textTheme: textTheme(ThemeData().textTheme),
+      segmentedButtonTheme: SegmentedButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.resolveWith<Color>(
+            (Set<MaterialState> states) {
+              return states.contains(MaterialState.selected)
+                  ? lightColorScheme.surface
+                  : lightColorScheme.secondaryContainer;
+            },
+          ),
+          side: MaterialStateProperty.resolveWith<BorderSide>(
+            (Set<MaterialState> _) {
+              return BorderSide(
+                color: lightColorScheme.secondaryContainer,
+                width: Grid.half,
+              );
+            },
+          ),
+          shape: MaterialStateProperty.all(
+            RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(Grid.xs)),
+          ),
+        ),
+      ),
     );
 
 ThemeData darkTheme(BuildContext context) => ThemeData(
       useMaterial3: true,
       colorScheme: darkColorScheme,
       textTheme: textTheme(ThemeData.dark().textTheme),
+      segmentedButtonTheme: SegmentedButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.resolveWith<Color>(
+            (Set<MaterialState> states) {
+              return states.contains(MaterialState.selected)
+                  ? darkColorScheme.surface
+                  : darkColorScheme.secondaryContainer;
+            },
+          ),
+          side: MaterialStateProperty.resolveWith<BorderSide>(
+            (Set<MaterialState> _) {
+              return BorderSide(
+                color: darkColorScheme.secondaryContainer,
+                width: Grid.half,
+              );
+            },
+          ),
+          shape: MaterialStateProperty.all(
+            RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(Grid.xs)),
+          ),
+        ),
+      ),
     );

--- a/frontend/test/shared/json_schema_form_test.dart
+++ b/frontend/test/shared/json_schema_form_test.dart
@@ -50,13 +50,13 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('Submit'));
+      await tester.tap(find.text('Next'));
       await tester.pump();
       expect(find.text('This field cannot be empty'), findsNWidgets(2));
 
       await tester.enterText(find.byType(TextFormField).at(0), 'A');
       await tester.enterText(find.byType(TextFormField).at(1), 'invalid_email');
-      await tester.tap(find.text('Submit'));
+      await tester.tap(find.text('Next'));
       await tester.pump();
 
       expect(find.text('Minimum length is 2 characters'), findsOneWidget);
@@ -80,7 +80,7 @@ void main() {
       await tester.enterText(find.byType(TextFormField).at(0), 'John');
       await tester.enterText(
           find.byType(TextFormField).at(1), 'john@example.com');
-      await tester.tap(find.text('Submit'));
+      await tester.tap(find.text('Next'));
       await tester.pump();
 
       expect(

--- a/frontend/test/shared/payment_details_page_test.dart
+++ b/frontend/test/shared/payment_details_page_test.dart
@@ -132,11 +132,11 @@ void main() {
         ),
       );
 
-      expect(find.byType(SegmentedButton<String>), findsOneWidget);
-      expect(
-          find.widgetWithText(SegmentedButton<String>, 'MOMO'), findsOneWidget);
-      expect(
-          find.widgetWithText(SegmentedButton<String>, 'BANK'), findsOneWidget);
+      expect(find.byType(SegmentedButton<String?>), findsOneWidget);
+      expect(find.widgetWithText(SegmentedButton<String?>, 'MOMO'),
+          findsOneWidget);
+      expect(find.widgetWithText(SegmentedButton<String?>, 'BANK'),
+          findsOneWidget);
     });
 
     testWidgets('should show momo, bank, and wallet payment type segments',
@@ -165,12 +165,12 @@ void main() {
         ),
       );
 
-      expect(find.byType(SegmentedButton<String>), findsOneWidget);
-      expect(
-          find.widgetWithText(SegmentedButton<String>, 'MOMO'), findsOneWidget);
-      expect(
-          find.widgetWithText(SegmentedButton<String>, 'BANK'), findsOneWidget);
-      expect(find.widgetWithText(SegmentedButton<String>, 'WALLET'),
+      expect(find.byType(SegmentedButton<String?>), findsOneWidget);
+      expect(find.widgetWithText(SegmentedButton<String?>, 'MOMO'),
+          findsOneWidget);
+      expect(find.widgetWithText(SegmentedButton<String?>, 'BANK'),
+          findsOneWidget);
+      expect(find.widgetWithText(SegmentedButton<String?>, 'WALLET'),
           findsOneWidget);
     });
 

--- a/frontend/test/shared/payment_details_page_test.dart
+++ b/frontend/test/shared/payment_details_page_test.dart
@@ -1,0 +1,285 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_starter/shared/payment_details_page.dart';
+import 'package:flutter_starter/shared/payment_method.dart';
+import 'package:flutter_starter/shared/search_payment_methods_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/widget_helpers.dart';
+
+void main() {
+  group('PaymentDetailsPage', () {
+    testWidgets('should show make sure this information is correct',
+        (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+        ),
+      );
+
+      expect(
+          find.text('Make sure this information is correct.'), findsOneWidget);
+    });
+
+    testWidgets('should show next button', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+        ),
+      );
+
+      expect(find.widgetWithText(FilledButton, 'Next'), findsOneWidget);
+    });
+
+    testWidgets('should show enter your momo details', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.text('Enter your momo details'), findsOneWidget);
+    });
+
+    testWidgets('should show enter your bank details', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  requiredPaymentDetails: bankSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.text('Enter your bank details'), findsOneWidget);
+    });
+
+    testWidgets('should show enter your wallet details', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'WALLET_BTC ADDRESS',
+                  requiredPaymentDetails: walletSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.text('Enter your wallet details'), findsOneWidget);
+    });
+
+    testWidgets('should show no payment type segments', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.byType(SegmentedButton<String>), findsNothing);
+    });
+
+    testWidgets('should show momo and bank payment type segments',
+        (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  requiredPaymentDetails: bankSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.byType(SegmentedButton<String>), findsOneWidget);
+      expect(
+          find.widgetWithText(SegmentedButton<String>, 'MOMO'), findsOneWidget);
+      expect(
+          find.widgetWithText(SegmentedButton<String>, 'BANK'), findsOneWidget);
+    });
+
+    testWidgets('should show momo, bank, and wallet payment type segments',
+        (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  requiredPaymentDetails: bankSchema,
+                ),
+                PaymentMethod(
+                  kind: 'WALLET_BTC ADDRESS',
+                  requiredPaymentDetails: walletSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.byType(SegmentedButton<String>), findsOneWidget);
+      expect(
+          find.widgetWithText(SegmentedButton<String>, 'MOMO'), findsOneWidget);
+      expect(
+          find.widgetWithText(SegmentedButton<String>, 'BANK'), findsOneWidget);
+      expect(find.widgetWithText(SegmentedButton<String>, 'WALLET'),
+          findsOneWidget);
+    });
+
+    testWidgets('should show payment provider', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      expect(find.byType(ListTile), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'MPESA'), findsOneWidget);
+      expect(find.textContaining('Service fee: 0.0'), findsOneWidget);
+    });
+
+    testWidgets('should show momo schema form', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      expect(find.byType(TextFormField), findsExactly(2));
+      expect(find.text('Phone number'), findsOneWidget);
+      expect(find.text('Reason for sending'), findsOneWidget);
+    });
+
+    testWidgets('should show bank schema form', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  requiredPaymentDetails: bankSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      expect(find.byType(TextFormField), findsExactly(2));
+      expect(find.text('Account number'), findsOneWidget);
+      expect(find.text('Reason for sending'), findsOneWidget);
+    });
+
+    testWidgets('should show wallet schema form', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'WALLET_BTC ADDRESS',
+                  requiredPaymentDetails: walletSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+      expect(find.byType(TextFormField), findsExactly(2));
+      expect(find.text('Wallet address'), findsOneWidget);
+      expect(find.text('Reason for sending'), findsOneWidget);
+    });
+
+    testWidgets(
+        'should show PaymentMethodsPage when payment provider is tapped',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: walletSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      await tester.tap(find.text('MPESA'));
+      await tester.pumpAndSettle();
+      expect(find.byType(SearchPaymentMethodsPage), findsOneWidget);
+    });
+  });
+}

--- a/frontend/test/shared/payment_details_page_test.dart
+++ b/frontend/test/shared/payment_details_page_test.dart
@@ -20,14 +20,16 @@ void main() {
           find.text('Make sure this information is correct.'), findsOneWidget);
     });
 
-    testWidgets('should show next button', (tester) async {
+    testWidgets('should show payment method selection zero state',
+        (tester) async {
       await tester.pumpWidget(
         WidgetHelpers.testableWidget(
           child: const PaymentDetailsPage(),
         ),
       );
 
-      expect(find.widgetWithText(FilledButton, 'Next'), findsOneWidget);
+      expect(find.text('Select a payment method'), findsOneWidget);
+      expect(find.text('Service fees may apply'), findsOneWidget);
     });
 
     testWidgets('should show enter your momo details', (tester) async {
@@ -174,7 +176,9 @@ void main() {
           findsOneWidget);
     });
 
-    testWidgets('should show payment provider', (tester) async {
+    testWidgets(
+        'should show SearchPaymentMethodsPage on tap of select a payment method',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         WidgetHelpers.testableWidget(
           child: const PaymentDetailsPage(),
@@ -190,6 +194,37 @@ void main() {
           ],
         ),
       );
+
+      await tester.tap(find.text('Select a payment method'));
+      await tester.pumpAndSettle();
+      expect(find.byType(SearchPaymentMethodsPage), findsOneWidget);
+    });
+
+    testWidgets(
+        'should show payment name after SearchPaymentMethodsPage selection',
+        (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: const PaymentDetailsPage(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      await tester.tap(find.text('Select a payment method'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('MPESA'));
+      await tester.pumpAndSettle();
+
       expect(find.byType(ListTile), findsOneWidget);
       expect(find.widgetWithText(ListTile, 'MPESA'), findsOneWidget);
       expect(find.textContaining('Service fee: 0.0'), findsOneWidget);
@@ -211,6 +246,13 @@ void main() {
           ],
         ),
       );
+
+      await tester.tap(find.text('Select a payment method'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('MPESA'));
+      await tester.pumpAndSettle();
+
       expect(find.byType(TextFormField), findsExactly(2));
       expect(find.text('Phone number'), findsOneWidget);
       expect(find.text('Reason for sending'), findsOneWidget);
@@ -232,6 +274,13 @@ void main() {
           ],
         ),
       );
+
+      await tester.tap(find.text('Select a payment method'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('GT BANK'));
+      await tester.pumpAndSettle();
+
       expect(find.byType(TextFormField), findsExactly(2));
       expect(find.text('Account number'), findsOneWidget);
       expect(find.text('Reason for sending'), findsOneWidget);
@@ -253,33 +302,16 @@ void main() {
           ],
         ),
       );
+
+      await tester.tap(find.text('Select a payment method'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('BTC ADDRESS'));
+      await tester.pumpAndSettle();
+
       expect(find.byType(TextFormField), findsExactly(2));
       expect(find.text('Wallet address'), findsOneWidget);
       expect(find.text('Reason for sending'), findsOneWidget);
-    });
-
-    testWidgets(
-        'should show PaymentMethodsPage when payment provider is tapped',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(
-        WidgetHelpers.testableWidget(
-          child: const PaymentDetailsPage(),
-          overrides: [
-            paymentMethodProvider.overrideWith(
-              (ref) => [
-                PaymentMethod(
-                  kind: 'MOMO_MPESA',
-                  requiredPaymentDetails: walletSchema,
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-
-      await tester.tap(find.text('MPESA'));
-      await tester.pumpAndSettle();
-      expect(find.byType(SearchPaymentMethodsPage), findsOneWidget);
     });
   });
 }

--- a/frontend/test/shared/search_payment_methods_page_test.dart
+++ b/frontend/test/shared/search_payment_methods_page_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_starter/shared/payment_method.dart';
+import 'package:flutter_starter/shared/search_payment_methods_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/widget_helpers.dart';
+
+final _paymentMethods = [
+  PaymentMethod(
+    kind: 'BANK_ACCESS BANK',
+    requiredPaymentDetails: bankSchema,
+    fee: '9.0',
+  ),
+  PaymentMethod(
+    kind: 'MOMO_MTN',
+    requiredPaymentDetails: momoSchema,
+  ),
+  PaymentMethod(
+    kind: 'WALLET_BTC ADDRESS',
+    requiredPaymentDetails: walletSchema,
+    fee: '5.0',
+  ),
+];
+
+void main() {
+  group('SearchPaymentMethodsPage', () {
+    testWidgets('should show search field', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentMethodsPage(
+            selectedPaymentMethod:
+                ValueNotifier<PaymentMethod>(_paymentMethods.first),
+            paymentMethods: _paymentMethods,
+          ),
+        ),
+      );
+
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.text('Search'), findsOneWidget);
+    });
+
+    testWidgets('should show payment method list', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentMethodsPage(
+            selectedPaymentMethod:
+                ValueNotifier<PaymentMethod>(_paymentMethods.first),
+            paymentMethods: _paymentMethods,
+          ),
+        ),
+      );
+
+      expect(find.byType(ListTile), findsExactly(3));
+      expect(find.widgetWithText(ListTile, 'ACCESS BANK'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'MTN'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'BTC ADDRESS'), findsOneWidget);
+    });
+
+    testWidgets('should show a payment method after valid search',
+        (tester) async {
+      final selectedPaymentMethod = ValueNotifier<PaymentMethod>(
+        _paymentMethods.first,
+      );
+
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentMethodsPage(
+            selectedPaymentMethod: selectedPaymentMethod,
+            paymentMethods: _paymentMethods,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'MTN');
+      await tester.pump();
+
+      expect(find.byType(ListTile), findsExactly(1));
+      expect(find.widgetWithText(ListTile, 'MTN'), findsOneWidget);
+    });
+
+    testWidgets('should show no payment methods after invalid search',
+        (tester) async {
+      final selectedPaymentMethod = ValueNotifier<PaymentMethod>(
+        _paymentMethods.first,
+      );
+
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentMethodsPage(
+            selectedPaymentMethod: selectedPaymentMethod,
+            paymentMethods: _paymentMethods,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'invalid');
+      await tester.pump();
+
+      expect(find.byType(ListTile), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
closes https://github.com/TBD54566975/didpay/issues/39

uses a `SegmentedButton` at top to toggle different payment types (i.e. `bank` or `momo`) and implemented `SearchPaymentMethodsPage` to search for different payment subtypes (e.g. `MTN` or `MPESA`)

also uses `JsonSchemaForm` to build dynamic forms based on mock schemas dependent on the payment types

https://github.com/TBD54566975/didpay/assets/125412902/22a01d18-4485-4695-8c63-69cf7bb2ef37


https://github.com/TBD54566975/didpay/assets/125412902/855fb150-b4aa-4a5c-86b5-a77619df2794

