### PR TITLE
feat: add payment type selector

### DIFF
--- a/lib/features/home/transaction.dart
+++ b/lib/features/home/transaction.dart
@@ -1,7 +1,7 @@
 import 'package:didpay/features/currency/currency.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-// TODO: remove this file when FTL generated types are available
+// TODO: remove this file when tbdex-dart is ready
 class Transaction {
   final double payinAmount;
   final double payoutAmount;

--- a/lib/features/payment/payment_method.dart
+++ b/lib/features/payment/payment_method.dart
@@ -1,41 +1,55 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-// TODO: remove this file when FTL generated types are available
+// TODO: remove this file when tbdex-dart is ready
 class PaymentMethod {
   final String kind;
+  final String name;
   final String requiredPaymentDetails;
+  final String? group;
   final String? fee;
 
   PaymentMethod({
     required this.kind,
+    required this.name,
     required this.requiredPaymentDetails,
+    this.group,
     this.fee,
   });
 }
 
 final _defaultList = [
   PaymentMethod(
-    kind: 'BANK_ACCESS BANK',
+    kind: 'AB',
+    name: 'Access Bank',
     requiredPaymentDetails: bankSchema,
-    fee: '9.0',
+    group: 'Bank',
+    fee: '9',
   ),
   PaymentMethod(
-    kind: 'BANK_GT BANK',
+    kind: 'GTB',
+    name: 'GT Bank',
     requiredPaymentDetails: bankSchema,
-    fee: '8.0',
+    group: 'Bank',
+    fee: '8',
   ),
   PaymentMethod(
-    kind: 'BANK_UNITED BANK FOR AFRICA',
+    kind: 'UBFA',
+    name: 'United Bank for Africa',
     requiredPaymentDetails: bankSchema,
-    fee: '10.0',
+    group: 'Bank',
+    fee: '10',
   ),
   PaymentMethod(
-    kind: 'MOMO_MTN',
+    kind: 'MTN',
+    name: 'MTN',
     requiredPaymentDetails: momoSchema,
+    group: 'Mobile money',
   ),
   PaymentMethod(
-    kind: 'MOMO_MPESA',
+    kind: 'MPESA',
+    name: 'M-Pesa',
     requiredPaymentDetails: momoSchema,
+    group: 'Mobile money',
   ),
   // PaymentMethod(
   //   kind: 'WALLET_BTC ADDRESS',

--- a/lib/features/payment/search_payment_types_page.dart
+++ b/lib/features/payment/search_payment_types_page.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:didpay/features/payment/payment_method.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/theme/grid.dart';
 
-class SearchPaymentMethodsPage extends HookWidget {
+class SearchPaymentTypesPage extends HookWidget {
   final _formKey = GlobalKey<FormState>();
-  final ValueNotifier<PaymentMethod?> selectedPaymentMethod;
-  final List<PaymentMethod>? paymentMethods;
+  final ValueNotifier<String?> selectedPaymentType;
+  final Set<String?>? paymentTypes;
   final String payinCurrency;
 
-  SearchPaymentMethodsPage({
-    required this.selectedPaymentMethod,
-    required this.paymentMethods,
+  SearchPaymentTypesPage({
+    required this.selectedPaymentType,
+    required this.paymentTypes,
     required this.payinCurrency,
     super.key,
   });
@@ -25,7 +24,7 @@ class SearchPaymentMethodsPage extends HookWidget {
     return Scaffold(
       appBar: AppBar(
         scrolledUnderElevation: 0,
-        title: Text(Loc.of(context).paymentMethods),
+        title: Text(Loc.of(context).paymentTypes),
       ),
       body: SafeArea(
         child: Column(
@@ -66,9 +65,9 @@ class SearchPaymentMethodsPage extends HookWidget {
             Expanded(
               child: _buildList(
                 context,
-                selectedPaymentMethod,
+                selectedPaymentType,
                 searchText,
-                paymentMethods,
+                paymentTypes,
               ),
             ),
           ],
@@ -79,42 +78,35 @@ class SearchPaymentMethodsPage extends HookWidget {
 
   Widget _buildList(
     BuildContext context,
-    ValueNotifier<PaymentMethod?> selectedPaymentMethod,
+    ValueNotifier<String?> selectedPaymentMethod,
     ValueNotifier<String> searchText,
-    List<PaymentMethod>? paymentMethods,
+    Set<String?>? paymentTypes,
   ) {
-    final filteredPaymentMethods = paymentMethods
+    final filteredPaymentTypes = paymentTypes
         ?.where((entry) =>
-            entry.name.toLowerCase().contains(searchText.value.toLowerCase()))
+            entry?.toLowerCase().contains(searchText.value.toLowerCase()) ??
+            false)
         .toList();
 
     return ListView.builder(
       itemBuilder: (context, index) {
-        final currentPaymentMethod =
-            filteredPaymentMethods?.elementAtOrNull(index);
-        final fee = (double.tryParse(currentPaymentMethod?.fee ?? '0.00')
-                ?.toStringAsFixed(2) ??
-            '0.00');
+        final currentPaymentType = filteredPaymentTypes?.elementAtOrNull(index);
 
         return ListTile(
           visualDensity: VisualDensity.compact,
-          selected: selectedPaymentMethod.value == currentPaymentMethod,
-          title: Text(currentPaymentMethod?.name ?? ''),
-          subtitle: Text(
-            Loc.of(context).serviceFeeAmount(fee, payinCurrency),
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
-          trailing: selectedPaymentMethod.value == currentPaymentMethod
+          selected: selectedPaymentMethod.value == currentPaymentType,
+          title: Text(currentPaymentType ?? ''),
+          trailing: selectedPaymentMethod.value == currentPaymentType
               ? const Icon(Icons.check)
               : null,
           onTap: () {
             selectedPaymentMethod.value =
-                currentPaymentMethod ?? selectedPaymentMethod.value;
+                currentPaymentType ?? selectedPaymentMethod.value;
             Navigator.of(context).pop();
           },
         );
       },
-      itemCount: filteredPaymentMethods?.length,
+      itemCount: filteredPaymentTypes?.length,
     );
   }
 }

--- a/lib/features/request/review_request_page.dart
+++ b/lib/features/request/review_request_page.dart
@@ -178,9 +178,11 @@ class ReviewRequestPage extends HookWidget {
             exchangeRate: exchangeRate,
             serviceFee: double.parse(serviceFee).toStringAsFixed(2),
             total: payinCurrency != Loc.of(context).usd
-                ? (double.parse(payinAmount) + double.parse(serviceFee))
+                ? (double.parse(payinAmount.replaceAll(',', '')) +
+                        double.parse(serviceFee))
                     .toStringAsFixed(2)
-                : (double.parse(payoutAmount) + double.parse(serviceFee))
+                : (double.parse(payoutAmount.replaceAll(',', '')) +
+                        double.parse(serviceFee))
                     .toStringAsFixed(2)),
       );
 

--- a/lib/features/request/withdraw_page.dart
+++ b/lib/features/request/withdraw_page.dart
@@ -82,7 +82,7 @@ class WithdrawPage extends HookConsumerWidget {
                     MaterialPageRoute(
                       builder: (context) => PaymentDetailsPage(
                         payinAmount: payinAmount.value,
-                        payinCurrency: Loc.of(context).usd,
+                        payinCurrency: CurrencyCode.usdc.toString(),
                         payoutAmount: Currency.formatFromDouble(
                           payoutAmount.value,
                           currency: CurrencyCode.values

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -41,14 +41,7 @@
     "yourPaymentWasSent": "Your payment was sent!",
     "verificationComplete": "Verification complete!",
     "makeSureInfoIsCorrect": "Make sure this information is correct.",
-    "enterYourPaymentChannelDetails": "Enter your {paymentChannel} details",
-    "@enterYourPaymentChannelDetails": {
-         "placeholders": {
-            "paymentChannel": {
-                "type": "String"
-            }
-        }
-    },
+    "enterYourPaymentDetails": "Enter your payment details",
     "serviceFeeAmount": "Service fee: {amount} {currency}",
     "@serviceFeeAmount": {
         "placeholders": {
@@ -98,5 +91,8 @@
     "availableBalance": "Available balance: ",
     "selectWallet": "Select your wallet",
     "selectWalletDescription": "We recommend you use DidPay with a compatible digital wallet. Select from the following options.",
-    "error": "Error"
+    "error": "Error",
+    "selectPaymentType": "Select a payment type",
+    "paymentMethods": "Payment methods",
+    "paymentTypes": "Payment types"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -301,11 +301,11 @@ abstract class Loc {
   /// **'Make sure this information is correct.'**
   String get makeSureInfoIsCorrect;
 
-  /// No description provided for @enterYourPaymentChannelDetails.
+  /// No description provided for @enterYourPaymentDetails.
   ///
   /// In en, this message translates to:
-  /// **'Enter your {paymentChannel} details'**
-  String enterYourPaymentChannelDetails(String paymentChannel);
+  /// **'Enter your payment details'**
+  String get enterYourPaymentDetails;
 
   /// No description provided for @serviceFeeAmount.
   ///
@@ -504,6 +504,24 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Error'**
   String get error;
+
+  /// No description provided for @selectPaymentType.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a payment type'**
+  String get selectPaymentType;
+
+  /// No description provided for @paymentMethods.
+  ///
+  /// In en, this message translates to:
+  /// **'Payment methods'**
+  String get paymentMethods;
+
+  /// No description provided for @paymentTypes.
+  ///
+  /// In en, this message translates to:
+  /// **'Payment types'**
+  String get paymentTypes;
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -112,9 +112,7 @@ class LocEn extends Loc {
   String get makeSureInfoIsCorrect => 'Make sure this information is correct.';
 
   @override
-  String enterYourPaymentChannelDetails(String paymentChannel) {
-    return 'Enter your $paymentChannel details';
-  }
+  String get enterYourPaymentDetails => 'Enter your payment details';
 
   @override
   String serviceFeeAmount(String amount, String currency) {
@@ -218,4 +216,13 @@ class LocEn extends Loc {
 
   @override
   String get error => 'Error';
+
+  @override
+  String get selectPaymentType => 'Select a payment type';
+
+  @override
+  String get paymentMethods => 'Payment methods';
+
+  @override
+  String get paymentTypes => 'Payment types';
 }

--- a/test/features/payment/payment_details_page_test.dart
+++ b/test/features/payment/payment_details_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:didpay/features/home/transaction.dart';
 import 'package:didpay/features/payment/payment_details_page.dart';
+import 'package:didpay/features/payment/search_payment_types_page.dart';
 import 'package:flutter/material.dart';
 import 'package:didpay/features/payment/payment_method.dart';
 import 'package:didpay/features/payment/search_payment_methods_page.dart';
@@ -23,27 +24,101 @@ void main() {
           ),
           overrides: overrides,
         );
-    testWidgets('should show make sure this information is correct',
-        (tester) async {
+    testWidgets('should show header', (tester) async {
       await tester.pumpWidget(
         WidgetHelpers.testableWidget(child: paymentDetailsPageTestWidget()),
       );
 
+      expect(find.text('Enter your payment details'), findsOneWidget);
       expect(
           find.text('Make sure this information is correct.'), findsOneWidget);
+    });
+
+    testWidgets('should show payment type selection zero state',
+        (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: paymentDetailsPageTestWidget(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  group: 'Mobile money',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  name: 'GT Bank',
+                  group: 'Bank',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.text('Select a payment type'), findsOneWidget);
+    });
+
+    testWidgets('should not show payment type selector', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: paymentDetailsPageTestWidget(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  group: 'Mobile money',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'MOMO_MTN',
+                  name: 'MTN',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(find.text('Select a payment type'), findsNothing);
     });
 
     testWidgets('should show payment method selection zero state',
         (tester) async {
       await tester.pumpWidget(
-        WidgetHelpers.testableWidget(child: paymentDetailsPageTestWidget()),
+        WidgetHelpers.testableWidget(
+          child: paymentDetailsPageTestWidget(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'MOMO_MTN',
+                  name: 'MTN',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
       );
 
       expect(find.text('Select a payment method'), findsOneWidget);
       expect(find.text('Service fees may apply'), findsOneWidget);
     });
 
-    testWidgets('should show enter your momo details', (tester) async {
+    testWidgets('should show payment method without selector', (tester) async {
       await tester.pumpWidget(
         WidgetHelpers.testableWidget(
           child: paymentDetailsPageTestWidget(),
@@ -52,6 +127,7 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
                   requiredPaymentDetails: momoSchema,
                 ),
               ],
@@ -60,50 +136,13 @@ void main() {
         ),
       );
 
-      expect(find.text('Enter your momo details'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'M-Pesa'), findsOneWidget);
+      expect(find.widgetWithIcon(Icon, Icons.chevron_right), findsNothing);
     });
 
-    testWidgets('should show enter your bank details', (tester) async {
-      await tester.pumpWidget(
-        WidgetHelpers.testableWidget(
-          child: paymentDetailsPageTestWidget(),
-          overrides: [
-            paymentMethodProvider.overrideWith(
-              (ref) => [
-                PaymentMethod(
-                  kind: 'BANK_GT BANK',
-                  requiredPaymentDetails: bankSchema,
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-
-      expect(find.text('Enter your bank details'), findsOneWidget);
-    });
-
-    testWidgets('should show enter your wallet details', (tester) async {
-      await tester.pumpWidget(
-        WidgetHelpers.testableWidget(
-          child: paymentDetailsPageTestWidget(),
-          overrides: [
-            paymentMethodProvider.overrideWith(
-              (ref) => [
-                PaymentMethod(
-                  kind: 'WALLET_BTC ADDRESS',
-                  requiredPaymentDetails: walletSchema,
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-
-      expect(find.text('Enter your wallet details'), findsOneWidget);
-    });
-
-    testWidgets('should show no payment type segments', (tester) async {
+    testWidgets(
+        'should show SearchPaymentTypesPage on tap of select a payment type',
+        (WidgetTester tester) async {
       await tester.pumpWidget(
         WidgetHelpers.testableWidget(
           child: paymentDetailsPageTestWidget(),
@@ -112,79 +151,25 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'MOMO_MPESA',
-                  requiredPaymentDetails: momoSchema,
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-
-      expect(find.byType(SegmentedButton<String>), findsNothing);
-    });
-
-    testWidgets('should show momo and bank payment type segments',
-        (tester) async {
-      await tester.pumpWidget(
-        WidgetHelpers.testableWidget(
-          child: paymentDetailsPageTestWidget(),
-          overrides: [
-            paymentMethodProvider.overrideWith(
-              (ref) => [
-                PaymentMethod(
-                  kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  group: 'Mobile money',
                   requiredPaymentDetails: momoSchema,
                 ),
                 PaymentMethod(
                   kind: 'BANK_GT BANK',
-                  requiredPaymentDetails: bankSchema,
-                ),
-              ],
-            ),
-          ],
-        ),
-      );
-
-      expect(find.byType(SegmentedButton<String?>), findsOneWidget);
-      expect(find.widgetWithText(SegmentedButton<String?>, 'MOMO'),
-          findsOneWidget);
-      expect(find.widgetWithText(SegmentedButton<String?>, 'BANK'),
-          findsOneWidget);
-    });
-
-    testWidgets('should show momo, bank, and wallet payment type segments',
-        (tester) async {
-      await tester.pumpWidget(
-        WidgetHelpers.testableWidget(
-          child: paymentDetailsPageTestWidget(),
-          overrides: [
-            paymentMethodProvider.overrideWith(
-              (ref) => [
-                PaymentMethod(
-                  kind: 'MOMO_MPESA',
+                  name: 'GT Bank',
+                  group: 'Bank',
                   requiredPaymentDetails: momoSchema,
                 ),
-                PaymentMethod(
-                  kind: 'BANK_GT BANK',
-                  requiredPaymentDetails: bankSchema,
-                ),
-                PaymentMethod(
-                  kind: 'WALLET_BTC ADDRESS',
-                  requiredPaymentDetails: walletSchema,
-                ),
               ],
             ),
           ],
         ),
       );
 
-      expect(find.byType(SegmentedButton<String?>), findsOneWidget);
-      expect(find.widgetWithText(SegmentedButton<String?>, 'MOMO'),
-          findsOneWidget);
-      expect(find.widgetWithText(SegmentedButton<String?>, 'BANK'),
-          findsOneWidget);
-      expect(find.widgetWithText(SegmentedButton<String?>, 'WALLET'),
-          findsOneWidget);
+      await tester.tap(find.text('Select a payment type'));
+      await tester.pumpAndSettle();
+      expect(find.byType(SearchPaymentTypesPage), findsOneWidget);
     });
 
     testWidgets(
@@ -198,6 +183,12 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'MOMO_MTN',
+                  name: 'MTN',
                   requiredPaymentDetails: momoSchema,
                 ),
               ],
@@ -212,6 +203,42 @@ void main() {
     });
 
     testWidgets(
+        'should show payment type after SearchPaymentTypesPage selection',
+        (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: paymentDetailsPageTestWidget(),
+          overrides: [
+            paymentMethodProvider.overrideWith(
+              (ref) => [
+                PaymentMethod(
+                  kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  group: 'Mobile money',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  name: 'GT Bank',
+                  group: 'Bank',
+                  requiredPaymentDetails: momoSchema,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      await tester.tap(find.text('Select a payment type'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Bank'));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(ListTile, 'Bank'), findsOneWidget);
+    });
+
+    testWidgets(
         'should show payment name after SearchPaymentMethodsPage selection',
         (tester) async {
       await tester.pumpWidget(
@@ -222,6 +249,12 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
+                  requiredPaymentDetails: momoSchema,
+                ),
+                PaymentMethod(
+                  kind: 'BANK_GT BANK',
+                  name: 'GT Bank',
                   requiredPaymentDetails: momoSchema,
                 ),
               ],
@@ -233,12 +266,10 @@ void main() {
       await tester.tap(find.text('Select a payment method'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('MPESA'));
+      await tester.tap(find.text('M-Pesa'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(ListTile), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'MPESA'), findsOneWidget);
-      expect(find.textContaining('Service fee: 0.0'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'M-Pesa'), findsOneWidget);
     });
 
     testWidgets('should show momo schema form', (tester) async {
@@ -250,6 +281,7 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'MOMO_MPESA',
+                  name: 'M-Pesa',
                   requiredPaymentDetails: momoSchema,
                 ),
               ],
@@ -257,12 +289,6 @@ void main() {
           ],
         ),
       );
-
-      await tester.tap(find.text('Select a payment method'));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('MPESA'));
-      await tester.pumpAndSettle();
 
       expect(find.byType(TextFormField), findsExactly(2));
       expect(find.text('Phone number'), findsOneWidget);
@@ -278,6 +304,7 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'BANK_GT BANK',
+                  name: 'GT Bank',
                   requiredPaymentDetails: bankSchema,
                 ),
               ],
@@ -285,12 +312,6 @@ void main() {
           ],
         ),
       );
-
-      await tester.tap(find.text('Select a payment method'));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('GT BANK'));
-      await tester.pumpAndSettle();
 
       expect(find.byType(TextFormField), findsExactly(2));
       expect(find.text('Account number'), findsOneWidget);
@@ -306,6 +327,7 @@ void main() {
               (ref) => [
                 PaymentMethod(
                   kind: 'WALLET_BTC ADDRESS',
+                  name: 'BTC Address',
                   requiredPaymentDetails: walletSchema,
                 ),
               ],
@@ -313,12 +335,6 @@ void main() {
           ],
         ),
       );
-
-      await tester.tap(find.text('Select a payment method'));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('BTC ADDRESS'));
-      await tester.pumpAndSettle();
 
       expect(find.byType(TextFormField), findsExactly(2));
       expect(find.text('Wallet address'), findsOneWidget);

--- a/test/features/payment/search_payment_methods_page_test.dart
+++ b/test/features/payment/search_payment_methods_page_test.dart
@@ -8,15 +8,18 @@ import '../../helpers/widget_helpers.dart';
 final _paymentMethods = [
   PaymentMethod(
     kind: 'BANK_ACCESS BANK',
+    name: 'Access Bank',
     requiredPaymentDetails: bankSchema,
     fee: '9.0',
   ),
   PaymentMethod(
     kind: 'MOMO_MTN',
+    name: 'MTN',
     requiredPaymentDetails: momoSchema,
   ),
   PaymentMethod(
     kind: 'WALLET_BTC ADDRESS',
+    name: 'BTC Address',
     requiredPaymentDetails: walletSchema,
     fee: '5.0',
   ),
@@ -54,9 +57,9 @@ void main() {
       );
 
       expect(find.byType(ListTile), findsExactly(3));
-      expect(find.widgetWithText(ListTile, 'ACCESS BANK'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'Access Bank'), findsOneWidget);
       expect(find.widgetWithText(ListTile, 'MTN'), findsOneWidget);
-      expect(find.widgetWithText(ListTile, 'BTC ADDRESS'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'BTC Address'), findsOneWidget);
     });
 
     testWidgets('should show a payment method after valid search',

--- a/test/features/payment/search_payment_types_page_test.dart
+++ b/test/features/payment/search_payment_types_page_test.dart
@@ -1,0 +1,93 @@
+import 'package:didpay/features/payment/search_payment_types_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/widget_helpers.dart';
+
+final _paymentTypes = {
+  'Bank',
+  'Mobile money',
+  'Wallet',
+};
+
+void main() {
+  group('SearchPaymentTypesPage', () {
+    testWidgets('should show search field', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentTypesPage(
+            selectedPaymentType: ValueNotifier<String>(_paymentTypes.first),
+            paymentTypes: _paymentTypes,
+            payinCurrency: '',
+          ),
+        ),
+      );
+
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+      expect(find.text('Search'), findsOneWidget);
+    });
+
+    testWidgets('should show payment type list', (tester) async {
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentTypesPage(
+            selectedPaymentType: ValueNotifier(_paymentTypes.first),
+            paymentTypes: _paymentTypes,
+            payinCurrency: '',
+          ),
+        ),
+      );
+
+      expect(find.byType(ListTile), findsExactly(3));
+      expect(find.widgetWithText(ListTile, 'Bank'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'Mobile money'), findsOneWidget);
+      expect(find.widgetWithText(ListTile, 'Wallet'), findsOneWidget);
+    });
+
+    testWidgets('should show a payment type after valid search',
+        (tester) async {
+      final selectedPaymentMethod = ValueNotifier(
+        _paymentTypes.first,
+      );
+
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentTypesPage(
+            selectedPaymentType: selectedPaymentMethod,
+            paymentTypes: _paymentTypes,
+            payinCurrency: '',
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'Bank');
+      await tester.pump();
+
+      expect(find.byType(ListTile), findsExactly(1));
+      expect(find.widgetWithText(ListTile, 'Bank'), findsOneWidget);
+    });
+
+    testWidgets('should show no payment types after invalid search',
+        (tester) async {
+      final selectedPaymentMethod = ValueNotifier(
+        _paymentTypes.first,
+      );
+
+      await tester.pumpWidget(
+        WidgetHelpers.testableWidget(
+          child: SearchPaymentTypesPage(
+            selectedPaymentType: selectedPaymentMethod,
+            paymentTypes: _paymentTypes,
+            payinCurrency: '',
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'invalid');
+      await tester.pump();
+
+      expect(find.byType(ListTile), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
closes https://github.com/TBD54566975/didpay/issues/87
removes the segmented buttons in `PaymentDetailsPage` to support the new [`group` type](https://github.com/TBD54566975/tbdex/blob/main/specs/protocol/README.md#payinmethod)


https://github.com/TBD54566975/didpay/assets/125412902/59911632-9027-4585-94d3-0fbdcfc6706e


https://github.com/TBD54566975/didpay/assets/125412902/77055dc2-9a14-4488-b1ae-950235b67989



