### PR TITLE
feat: support multiple pfis

### DIFF
--- a/lib/features/app/app.dart
+++ b/lib/features/app/app.dart
@@ -2,7 +2,6 @@ import 'package:didpay/features/app/app_tabs.dart';
 import 'package:didpay/features/pfis/add_pfi_page.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/l10n/app_localizations.dart';
-import 'package:didpay/shared/modal_flow.dart';
 import 'package:didpay/shared/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/lib/features/currency/currency_dropdown.dart
+++ b/lib/features/currency/currency_dropdown.dart
@@ -1,4 +1,5 @@
 import 'package:didpay/features/currency/currency_modal.dart';
+import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
@@ -7,13 +8,15 @@ import 'package:tbdex/tbdex.dart';
 
 class CurrencyDropdown extends HookConsumerWidget {
   final TransactionType transactionType;
+  final ValueNotifier<Pfi?> selectedPfi;
   final ValueNotifier<Offering?> selectedOffering;
-  final List<Offering> offerings;
+  final Map<Pfi, List<Offering>> offeringsMap;
 
   const CurrencyDropdown({
     required this.transactionType,
+    required this.selectedPfi,
     required this.selectedOffering,
-    required this.offerings,
+    required this.offeringsMap,
     super.key,
   });
 
@@ -33,8 +36,9 @@ class CurrencyDropdown extends HookConsumerWidget {
           CurrencyModal.show(
             context,
             transactionType,
+            selectedPfi,
             selectedOffering,
-            offerings,
+            offeringsMap,
           );
         },
       ),

--- a/lib/features/kcc/kcc_retrieval_page.dart
+++ b/lib/features/kcc/kcc_retrieval_page.dart
@@ -20,7 +20,6 @@ class KccRetrievalPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    print("HI I AM A RETRIEVER");
     final bearerDid = ref.watch(didProvider);
     final kccIssuanceService = ref.watch(kccIssuanceProvider);
     final credentialResponse =

--- a/lib/features/kcc/kcc_webview_page.dart
+++ b/lib/features/kcc/kcc_webview_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:didpay/features/account/account_providers.dart';
 import 'package:didpay/features/kcc/kcc_issuance_service.dart';

--- a/lib/features/payin/payin.dart
+++ b/lib/features/payin/payin.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:didpay/features/currency/currency_dropdown.dart';
+import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/shake_animated_text.dart';
@@ -14,15 +15,17 @@ class Payin extends HookWidget {
   final TransactionType transactionType;
   final ValueNotifier<String> amount;
   final ValueNotifier<PayinKeyPress> keyPress;
+  final ValueNotifier<Pfi?> selectedPfi;
   final ValueNotifier<Offering?> selectedOffering;
-  final List<Offering> offerings;
+  final Map<Pfi, List<Offering>> offeringsMap;
 
   const Payin({
     required this.transactionType,
     required this.amount,
     required this.keyPress,
+    required this.selectedPfi,
     required this.selectedOffering,
-    required this.offerings,
+    required this.offeringsMap,
     super.key,
   });
 
@@ -143,8 +146,9 @@ class Payin extends HookWidget {
       case TransactionType.deposit:
         return CurrencyDropdown(
           transactionType: transactionType,
+          selectedPfi: selectedPfi,
           selectedOffering: selectedOffering,
-          offerings: offerings,
+          offeringsMap: offeringsMap,
         );
       case TransactionType.withdraw:
       case TransactionType.send:

--- a/lib/features/payout/payout.dart
+++ b/lib/features/payout/payout.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:didpay/features/currency/currency_dropdown.dart';
+import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/theme/grid.dart';
@@ -12,15 +13,17 @@ class Payout extends HookWidget {
   final double payinAmount;
   final TransactionType transactionType;
   final ValueNotifier<double> payoutAmount;
+  final ValueNotifier<Pfi?> selectedPfi;
   final ValueNotifier<Offering?> selectedOffering;
-  final List<Offering> offerings;
+  final Map<Pfi, List<Offering>> offeringsMap;
 
   const Payout({
     required this.payinAmount,
     required this.transactionType,
     required this.payoutAmount,
+    required this.selectedPfi,
     required this.selectedOffering,
-    required this.offerings,
+    required this.offeringsMap,
     super.key,
   });
 
@@ -80,8 +83,9 @@ class Payout extends HookWidget {
       case TransactionType.withdraw:
         return CurrencyDropdown(
           transactionType: transactionType,
+          selectedPfi: selectedPfi,
           selectedOffering: selectedOffering,
-          offerings: offerings,
+          offeringsMap: offeringsMap,
         );
       case TransactionType.deposit:
       case TransactionType.send:

--- a/lib/features/tbdex/tbdex_service.dart
+++ b/lib/features/tbdex/tbdex_service.dart
@@ -8,46 +8,49 @@ import 'package:web5/web5.dart';
 final tbdexServiceProvider = Provider((_) => TbdexService());
 
 class TbdexService {
-  // TODO(ethan-tbd): return Map<Pfi, List<Offering>>
-  Future<List<Offering>> getOfferings(List<Pfi> pfis) async {
-    final offerings = <Offering>[];
+  Future<Map<Pfi, List<Offering>>> getOfferings(List<Pfi> pfis) async {
+    final offeringsMap = <Pfi, List<Offering>>{};
 
     for (final pfi in pfis) {
-      final response = await TbdexHttpClient.listOfferings(pfi.did);
-      if (response.statusCode.category == HttpStatus.success) {
-        offerings.addAll(response.data!);
+      try {
+        final response = await TbdexHttpClient.listOfferings(pfi.did);
+        if (response.statusCode.category == HttpStatus.success) {
+          offeringsMap[pfi] = response.data!;
+        }
+      } on Exception catch (_) {
+        rethrow;
       }
     }
 
-    if (offerings.isEmpty) {
+    if (offeringsMap.isEmpty) {
       throw Exception('no offerings found');
     }
 
-    return offerings;
+    return offeringsMap;
   }
 
   Future<Map<Pfi, List<String>>> getExchanges(
     BearerDid did,
     List<Pfi> pfis,
   ) async {
-    final exchangeMap = <Pfi, List<String>>{};
+    final exchangesMap = <Pfi, List<String>>{};
 
     for (final pfi in pfis) {
       try {
         final response = await TbdexHttpClient.listExchanges(did, pfi.did);
         if (response.statusCode.category == HttpStatus.success) {
-          exchangeMap[pfi] = response.data!;
+          exchangesMap[pfi] = response.data!;
         } else {
           throw Exception(
             'failed to fetch exchanges with status code ${response.statusCode}',
           );
         }
       } on Exception {
-        return exchangeMap;
+        return exchangesMap;
       }
     }
 
-    return exchangeMap;
+    return exchangesMap;
   }
 
   Future<List<Message>> getExchange(

--- a/lib/shared/theme/grid.dart
+++ b/lib/shared/theme/grid.dart
@@ -14,4 +14,5 @@ class Grid {
 
   static const double side = 20;
   static const double radius = 25;
+  static const double tileHeight = 80;
 }

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -24,7 +24,9 @@ void main() async {
   const pfi = Pfi(did: 'did:web:x%3A8892:ingress');
 
   final jsonList = jsonDecode(jsonString) as List<dynamic>;
-  final offerings = [Offering.fromJson(jsonList[0])];
+  final offerings = {
+    pfi: [Offering.fromJson(jsonList[0])],
+  };
   late MockTbdexService mockTbdexService;
 
   group('HomePage', () {

--- a/test/features/payin/payin_test.dart
+++ b/test/features/payin/payin_test.dart
@@ -1,4 +1,5 @@
 import 'package:didpay/features/payin/payin.dart';
+import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/shared/shake_animated_text.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ import '../../helpers/widget_helpers.dart';
 void main() {
   group('Payin', () {
     final amount = ValueNotifier<String>('70');
+    final pfi = ValueNotifier<Pfi?>(null);
     final offering = ValueNotifier<Offering?>(
       Offering.create(
         'pfiDid',
@@ -45,9 +47,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.deposit,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),
@@ -61,9 +64,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.deposit,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),
@@ -77,9 +81,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.deposit,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),
@@ -93,9 +98,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.withdraw,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),
@@ -109,9 +115,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.deposit,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),
@@ -126,9 +133,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.deposit,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),
@@ -143,9 +151,10 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payin(
             transactionType: TransactionType.withdraw,
-            offerings: const [],
+            offeringsMap: const {},
             amount: amount,
             keyPress: keyPress,
+            selectedPfi: pfi,
             selectedOffering: offering,
           ),
         ),

--- a/test/features/payment/payment_amount_page_test.dart
+++ b/test/features/payment/payment_amount_page_test.dart
@@ -22,7 +22,9 @@ void main() {
   const pfi = Pfi(did: 'did:web:x%3A8892:ingress');
 
   final jsonList = jsonDecode(jsonString) as List<dynamic>;
-  final offerings = [Offering.fromJson(jsonList[0])];
+  final offerings = {
+    pfi: [Offering.fromJson(jsonList[0])],
+  };
   late MockTbdexService mockTbdexService;
 
   group('PaymentAmountPage', () {

--- a/test/features/payout/payout_test.dart
+++ b/test/features/payout/payout_test.dart
@@ -1,4 +1,5 @@
 import 'package:didpay/features/payout/payout.dart';
+import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,6 +10,7 @@ import '../../helpers/widget_helpers.dart';
 void main() {
   group('Payout', () {
     final amount = ValueNotifier<double>(2);
+    final pfi = ValueNotifier<Pfi?>(null);
     final offering = ValueNotifier<Offering?>(
       Offering.create(
         'pfiDid',
@@ -43,10 +45,11 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payout(
             payoutAmount: amount,
+            selectedPfi: pfi,
             selectedOffering: offering,
             transactionType: TransactionType.deposit,
             payinAmount: 34,
-            offerings: const [],
+            offeringsMap: const {},
           ),
         ),
       );
@@ -59,10 +62,11 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payout(
             payoutAmount: amount,
+            selectedPfi: pfi,
             selectedOffering: offering,
             transactionType: TransactionType.deposit,
-            payinAmount: 0,
-            offerings: const [],
+            payinAmount: 34,
+            offeringsMap: const {},
           ),
         ),
       );
@@ -75,10 +79,11 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payout(
             payoutAmount: amount,
+            selectedPfi: pfi,
             selectedOffering: offering,
             transactionType: TransactionType.withdraw,
-            payinAmount: 0,
-            offerings: const [],
+            payinAmount: 34,
+            offeringsMap: const {},
           ),
         ),
       );
@@ -92,10 +97,11 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payout(
             payoutAmount: amount,
+            selectedPfi: pfi,
             selectedOffering: offering,
             transactionType: TransactionType.withdraw,
-            payinAmount: 0,
-            offerings: const [],
+            payinAmount: 34,
+            offeringsMap: const {},
           ),
         ),
       );
@@ -109,10 +115,11 @@ void main() {
         WidgetHelpers.testableWidget(
           child: Payout(
             payoutAmount: amount,
+            selectedPfi: pfi,
             selectedOffering: offering,
             transactionType: TransactionType.deposit,
-            payinAmount: 0,
-            offerings: const [],
+            payinAmount: 34,
+            offeringsMap: const {},
           ),
         ),
       );


### PR DESCRIPTION
this pr allows multiple pfis to be supported within didpay, including:
- viewing all offerings from every pfi loaded in `My PFIs`
- making http requests to the pfi that hosts the offering selected in `PaymentAmountPage`
