### PR TITLE
feat: add next button

### DIFF
--- a/lib/features/countries/countries_page.dart
+++ b/lib/features/countries/countries_page.dart
@@ -4,7 +4,7 @@ import 'package:didpay/features/payment/payment_amount_page.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/header.dart';
-import 'package:didpay/shared/theme/grid.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -30,7 +30,18 @@ class CountriesPage extends HookConsumerWidget {
             Expanded(
               child: _buildCountryList(context, ref, countries, country),
             ),
-            _buildNextButton(context, country.value),
+            NextButton(
+              onPressed: country.value == null
+                  ? null
+                  : () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) => PaymentAmountPage(
+                            transactionType: TransactionType.send,
+                            country: country.value,
+                          ),
+                        ),
+                      ),
+            ),
           ],
         ),
       ),
@@ -56,28 +67,5 @@ class CountriesPage extends HookConsumerWidget {
             onTap: () => selectedCountry.value = country,
           );
         },
-      );
-
-  Widget _buildNextButton(
-    BuildContext context,
-    Country? country,
-  ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-        child: FilledButton(
-          onPressed: country == null
-              ? null
-              : () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => PaymentAmountPage(
-                        transactionType: TransactionType.send,
-                        country: country,
-                      ),
-                    ),
-                  );
-                },
-          child: Text(Loc.of(context).next),
-        ),
       );
 }

--- a/lib/features/kcc/kcc_consent_page.dart
+++ b/lib/features/kcc/kcc_consent_page.dart
@@ -2,6 +2,7 @@ import 'package:didpay/features/kcc/kcc_webview_page.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/header.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -34,7 +35,15 @@ class KccConsentPage extends HookConsumerWidget {
             ),
             const Spacer(),
             _buildUserAndPrivacyAgreement(context, hasAgreed),
-            _buildNextButton(context, ref, hasAgreed.value),
+            NextButton(
+              onPressed: !hasAgreed.value
+                  ? null
+                  : () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => KccWebviewPage(pfi: pfi),
+                        ),
+                      ),
+            ),
           ],
         ),
       ),
@@ -87,27 +96,6 @@ class KccConsentPage extends HookConsumerWidget {
               ),
             ],
           ),
-        ),
-      );
-
-  Widget _buildNextButton(
-    BuildContext context,
-    WidgetRef ref,
-    bool hasAgreed,
-  ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-        child: FilledButton(
-          onPressed: !hasAgreed
-              ? null
-              : () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (_) => KccWebviewPage(pfi: pfi),
-                    ),
-                  );
-                },
-          child: Text(Loc.of(context).next),
         ),
       );
 }

--- a/lib/features/payment/payment_amount_page.dart
+++ b/lib/features/payment/payment_amount_page.dart
@@ -12,6 +12,7 @@ import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/async/async_error_widget.dart';
 import 'package:didpay/shared/async/async_loading_widget.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/number/number_key_press.dart';
 import 'package:didpay/shared/number/number_pad.dart';
 import 'package:didpay/shared/theme/grid.dart';
@@ -62,11 +63,21 @@ class PaymentAmountPage extends HookConsumerWidget {
             }
 
             final paymentState = PaymentState(
-              payinAmount: Decimal.parse(payinAmount.value),
               transactionType: transactionType,
+              payinAmount: Decimal.parse(payinAmount.value),
+              payoutAmount: payoutAmount.value,
               selectedPfi: selectedPfi.value,
               selectedOffering: selectedOffering.value,
               offeringsMap: offeringsMap,
+              payinCurrency:
+                  selectedOffering.value?.data.payin.currencyCode ?? '',
+              payoutCurrency:
+                  selectedOffering.value?.data.payout.currencyCode ?? '',
+              payinMethods: selectedOffering.value?.data.payin.methods ?? [],
+              payoutMethods: selectedOffering.value?.data.payout.methods ?? [],
+              exchangeRate: Decimal.parse(
+                selectedOffering.value?.data.payoutUnitsPerPayinUnit ?? '1',
+              ),
             );
 
             return Column(
@@ -112,26 +123,16 @@ class PaymentAmountPage extends HookConsumerWidget {
                   ),
                 ),
                 const SizedBox(height: Grid.sm),
-                _buildNextButton(
-                  context,
-                  paymentState.copyWith(
-                    payinAmount: Decimal.parse(payinAmount.value),
-                    payoutAmount: payoutAmount.value,
-                    selectedPfi: selectedPfi.value,
-                    selectedOffering: selectedOffering.value,
-                    payinCurrency:
-                        selectedOffering.value?.data.payin.currencyCode ?? '',
-                    payoutCurrency:
-                        selectedOffering.value?.data.payout.currencyCode ?? '',
-                    payinMethods:
-                        selectedOffering.value?.data.payin.methods ?? [],
-                    payoutMethods:
-                        selectedOffering.value?.data.payout.methods ?? [],
-                    exchangeRate: Decimal.parse(
-                      selectedOffering.value?.data.payoutUnitsPerPayinUnit ??
-                          '1',
-                    ),
-                  ),
+                NextButton(
+                  onPressed: paymentState.payinAmount == Decimal.zero
+                      ? null
+                      : () => Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (context) => PaymentDetailsPage(
+                                paymentState: paymentState,
+                              ),
+                            ),
+                          ),
                 ),
               ],
             );
@@ -146,25 +147,6 @@ class PaymentAmountPage extends HookConsumerWidget {
       ),
     );
   }
-
-  Widget _buildNextButton(
-    BuildContext context,
-    PaymentState paymentState,
-  ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-        child: FilledButton(
-          onPressed: paymentState.payinAmount == Decimal.zero
-              ? null
-              : () => Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) =>
-                          PaymentDetailsPage(paymentState: paymentState),
-                    ),
-                  ),
-          child: Text(Loc.of(context).next),
-        ),
-      );
 
   void _getOfferings(
     WidgetRef ref,

--- a/lib/features/payment/payment_review_page.dart
+++ b/lib/features/payment/payment_review_page.dart
@@ -11,6 +11,7 @@ import 'package:didpay/shared/async/async_error_widget.dart';
 import 'package:didpay/shared/async/async_loading_widget.dart';
 import 'package:didpay/shared/currency_formatter.dart';
 import 'package:didpay/shared/header.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -42,18 +43,19 @@ class PaymentReviewPage extends HookConsumerWidget {
       body: SafeArea(
         child: orderResponse.value == null
             ? quoteResponse.value.when(
-                data: (quote) => Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Header(
-                        title: Loc.of(context).reviewYourPayment,
-                        subtitle: Loc.of(context).makeSureInfoIsCorrect,
-                      ),
-                      Expanded(
-                        child: SingleChildScrollView(
-                          physics: const BouncingScrollPhysics(),
+                data: (quote) => Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Header(
+                      title: Loc.of(context).reviewYourPayment,
+                      subtitle: Loc.of(context).makeSureInfoIsCorrect,
+                    ),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        physics: const BouncingScrollPhysics(),
+                        child: Padding(
+                          padding:
+                              const EdgeInsets.symmetric(horizontal: Grid.side),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
@@ -65,14 +67,18 @@ class PaymentReviewPage extends HookConsumerWidget {
                           ),
                         ),
                       ),
-                      _buildSubmitButton(
+                    ),
+                    NextButton(
+                      onPressed: () => _submitOrder(
                         context,
                         ref,
-                        quote,
+                        paymentState,
                         orderResponse,
                       ),
-                    ],
-                  ),
+                      title:
+                          '${Loc.of(context).pay} ${PaymentFeeDetails.calculateTotalAmount(quote.data)} ${quote.data.payin.currencyCode}',
+                    ),
+                  ],
                 ),
                 loading: () => AsyncLoadingWidget(
                   text: Loc.of(context).gettingYourQuote,
@@ -201,24 +207,6 @@ class PaymentReviewPage extends HookConsumerWidget {
               ),
             ),
           ],
-        ),
-      );
-
-  Widget _buildSubmitButton(
-    BuildContext context,
-    WidgetRef ref,
-    Quote quote,
-    sendOrderState,
-  ) =>
-      FilledButton(
-        onPressed: () => _submitOrder(
-          context,
-          ref,
-          paymentState,
-          sendOrderState,
-        ),
-        child: Text(
-          '${Loc.of(context).pay} ${PaymentFeeDetails.calculateTotalAmount(quote.data)} ${quote.data.payin.currencyCode}',
         ),
       );
 

--- a/lib/features/pfis/add_pfi_page.dart
+++ b/lib/features/pfis/add_pfi_page.dart
@@ -7,6 +7,7 @@ import 'package:didpay/shared/async/async_data_widget.dart';
 import 'package:didpay/shared/async/async_error_widget.dart';
 import 'package:didpay/shared/async/async_loading_widget.dart';
 import 'package:didpay/shared/header.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -83,11 +84,14 @@ class AddPfiPage extends HookConsumerWidget {
                     errorText,
                     isPhysicalDevice: isPhysicalDevice.value,
                   ),
-                  _buildAddButton(
-                    ref,
-                    pfiDidController,
-                    addPfiState,
-                    errorText.value,
+                  NextButton(
+                    onPressed: () {
+                      if ((_formKey.currentState?.validate() ?? false) &&
+                          errorText.value == null) {
+                        _addPfi(ref, pfiDidController.text, addPfiState);
+                      }
+                    },
+                    title: Loc.of(context).add,
                   ),
                 ],
               ),
@@ -152,25 +156,6 @@ class AddPfiPage extends HookConsumerWidget {
               ),
             ],
           ),
-        ),
-      );
-
-  Widget _buildAddButton(
-    WidgetRef ref,
-    TextEditingController pfiDidController,
-    ValueNotifier<AsyncValue<Pfi>?> state,
-    String? errorText,
-  ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-        child: FilledButton(
-          onPressed: () {
-            if ((_formKey.currentState?.validate() ?? false) &&
-                errorText == null) {
-              _addPfi(ref, pfiDidController.text, state);
-            }
-          },
-          child: const Text('Add'),
         ),
       );
 

--- a/lib/features/send/send_details_page.dart
+++ b/lib/features/send/send_details_page.dart
@@ -5,6 +5,7 @@ import 'package:didpay/shared/async/async_data_widget.dart';
 import 'package:didpay/shared/async/async_error_widget.dart';
 import 'package:didpay/shared/async/async_loading_widget.dart';
 import 'package:didpay/shared/header.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -72,11 +73,14 @@ class SendDetailsPage extends HookConsumerWidget {
                     errorText,
                     isPhysicalDevice: isPhysicalDevice.value,
                   ),
-                  _buildSendButton(
-                    context,
-                    recipientDidController,
-                    sendResponse,
-                    errorText.value,
+                  NextButton(
+                    onPressed: () {
+                      if ((_formKey.currentState?.validate() ?? false) &&
+                          errorText.value == null) {
+                        _sendPayment(sendResponse);
+                      }
+                    },
+                    title: Loc.of(context).sendAmountUsdc(sendAmount),
                   ),
                 ],
               )
@@ -149,25 +153,6 @@ class SendDetailsPage extends HookConsumerWidget {
               ),
             ],
           ),
-        ),
-      );
-
-  Widget _buildSendButton(
-    BuildContext context,
-    TextEditingController recipientDidController,
-    ValueNotifier<AsyncValue<void>?> sendResponse,
-    String? errorText,
-  ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-        child: FilledButton(
-          onPressed: () {
-            if ((_formKey.currentState?.validate() ?? false) &&
-                errorText == null) {
-              _sendPayment(sendResponse);
-            }
-          },
-          child: Text(Loc.of(context).sendAmountUsdc(sendAmount)),
         ),
       );
 

--- a/lib/features/send/send_page.dart
+++ b/lib/features/send/send_page.dart
@@ -1,6 +1,7 @@
 import 'package:didpay/features/countries/countries_page.dart';
 import 'package:didpay/features/send/send_details_page.dart';
 import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/number/number_display.dart';
 import 'package:didpay/shared/number/number_key_press.dart';
 import 'package:didpay/shared/number/number_pad.dart';
@@ -66,7 +67,17 @@ class SendPage extends HookWidget {
                     NumberKeyPress(keyPress.value.count + 1, key),
               ),
             ),
-            _buildSendButton(context, amount.value),
+            NextButton(
+              onPressed: double.tryParse(amount.value) == 0
+                  ? null
+                  : () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) =>
+                              SendDetailsPage(sendAmount: amount.value),
+                        ),
+                      ),
+              title: Loc.of(context).send,
+            ),
           ],
         ),
       ),
@@ -82,22 +93,4 @@ class SendPage extends HookWidget {
               ),
         ),
       );
-
-  Widget _buildSendButton(BuildContext context, String amount) {
-    final disabled = double.tryParse(amount) == 0;
-
-    void onPressed() => Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => SendDetailsPage(sendAmount: amount),
-          ),
-        );
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-      child: FilledButton(
-        onPressed: disabled ? null : onPressed,
-        child: Text(Loc.of(context).send),
-      ),
-    );
-  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -141,5 +141,6 @@
     "issuedCredentials": "Issued credentials",
     "removeCredential": "Remove credential",
     "noCredentialsIssuedYet": "No credentials issued yet",
-    "selectCurrency": "Select currency"
+    "selectCurrency": "Select currency",
+    "add": "Add"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -756,6 +756,12 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Select currency'**
   String get selectCurrency;
+
+  /// No description provided for @add.
+  ///
+  /// In en, this message translates to:
+  /// **'Add'**
+  String get add;
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -344,4 +344,7 @@ class LocEn extends Loc {
 
   @override
   String get selectCurrency => 'Select currency';
+
+  @override
+  String get add => 'Add';
 }

--- a/lib/shared/async/async_data_widget.dart
+++ b/lib/shared/async/async_data_widget.dart
@@ -1,5 +1,6 @@
 import 'package:didpay/features/app/app.dart';
 import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -28,15 +29,12 @@ class AsyncDataWidget extends HookWidget {
               ],
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-            child: FilledButton(
-              onPressed: () => Navigator.of(context).pushAndRemoveUntil(
-                MaterialPageRoute(builder: (context) => const App()),
-                (route) => false,
-              ),
-              child: Text(Loc.of(context).done),
+          NextButton(
+            onPressed: () => Navigator.of(context).pushAndRemoveUntil(
+              MaterialPageRoute(builder: (context) => const App()),
+              (route) => false,
             ),
+            title: Loc.of(context).done,
           ),
         ],
       );

--- a/lib/shared/async/async_error_widget.dart
+++ b/lib/shared/async/async_error_widget.dart
@@ -1,6 +1,6 @@
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/header.dart';
-import 'package:didpay/shared/theme/grid.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -19,20 +19,14 @@ class AsyncErrorWidget extends HookConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-        child: Center(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Header(title: Loc.of(context).errorFound, subtitle: text),
-              Expanded(child: Container()),
-              FilledButton(
-                onPressed: onRetry,
-                child: Text(Loc.of(context).tapToRetry),
-              ),
-            ],
-          ),
+      Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Header(title: Loc.of(context).errorFound, subtitle: text),
+            const Expanded(child: Spacer()),
+            NextButton(onPressed: onRetry, title: Loc.of(context).tapToRetry),
+          ],
         ),
       );
 }

--- a/lib/shared/json_schema_form.dart
+++ b/lib/shared/json_schema_form.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:didpay/shared/utils/text_input_util.dart';
 import 'package:flutter/material.dart';
@@ -35,15 +35,7 @@ class JsonSchemaForm extends HookWidget {
       }
     }
 
-    if (schema == null) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const Spacer(),
-          _buildNextButton(context, onPressed),
-        ],
-      );
-    }
+    if (schema == null) return _buildEmptyForm(onPressed);
 
     final jsonSchema = json.decode(schema ?? '') as Map<String, dynamic>;
     final properties = jsonSchema['properties'] as Map<String, dynamic>?;
@@ -98,11 +90,19 @@ class JsonSchemaForm extends HookWidget {
               ),
             ),
           ),
-          _buildNextButton(context, onPressed),
+          NextButton(onPressed: isDisabled ? null : () => onPressed(formData)),
         ],
       ),
     );
   }
+
+  Widget _buildEmptyForm(Function(Map<String, String>) onPressed) => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Spacer(),
+          NextButton(onPressed: isDisabled ? null : () => onPressed(formData)),
+        ],
+      );
 
   String? _validateField(
     String key,
@@ -145,24 +145,4 @@ class JsonSchemaForm extends HookWidget {
 
     return null;
   }
-
-  Widget _buildNextButton(
-    BuildContext context,
-    void Function(Map<String, String>) onPressed,
-  ) =>
-      Expanded(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(child: Container()),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: Grid.side),
-              child: FilledButton(
-                onPressed: isDisabled ? null : () => onPressed(formData),
-                child: Text(Loc.of(context).next),
-              ),
-            ),
-          ],
-        ),
-      );
 }

--- a/lib/shared/next_button.dart
+++ b/lib/shared/next_button.dart
@@ -1,0 +1,20 @@
+import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/theme/grid.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class NextButton extends HookWidget {
+  final void Function()? onPressed;
+  final String? title;
+
+  const NextButton({required this.onPressed, this.title, super.key});
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: Grid.side),
+        child: FilledButton(
+          onPressed: onPressed,
+          child: Text(title ?? Loc.of(context).next),
+        ),
+      );
+}

--- a/test/features/send/send_page_test.dart
+++ b/test/features/send/send_page_test.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:didpay/features/did/did_provider.dart';
 import 'package:didpay/features/send/send_details_page.dart';
 import 'package:didpay/features/send/send_page.dart';
+import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/number/number_pad.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -35,10 +36,10 @@ void main() async {
         WidgetHelpers.testableWidget(child: const SendPage()),
       );
 
-      final nextButton = find.widgetWithText(FilledButton, 'Send');
+      final nextButton = find.widgetWithText(NextButton, 'Send');
 
       expect(
-        tester.widget<FilledButton>(nextButton).onPressed,
+        tester.widget<NextButton>(nextButton).onPressed,
         isNull,
       );
     });


### PR DESCRIPTION
this pr adds a shared `NextButton` widget to get rid of redundant `buildNextButton()` helper functions in every page 