### PR TITLE
feat: add lucid mode

### DIFF
--- a/lib/features/account/account_balance_card.dart
+++ b/lib/features/account/account_balance_card.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:didpay/features/account/account_balance_notifier.dart';
 import 'package:didpay/features/payment/payment_amount_page.dart';
+import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/l10n/app_localizations.dart';
@@ -107,7 +108,9 @@ class AccountBalanceCard extends HookConsumerWidget {
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => const PaymentAmountPage(
-                    transactionType: TransactionType.deposit,
+                    paymentState: PaymentState(
+                      transactionType: TransactionType.deposit,
+                    ),
                   ),
                 ),
               ),
@@ -120,7 +123,9 @@ class AccountBalanceCard extends HookConsumerWidget {
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => const PaymentAmountPage(
-                    transactionType: TransactionType.withdraw,
+                    paymentState: PaymentState(
+                      transactionType: TransactionType.withdraw,
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/countries/countries.dart
+++ b/lib/features/countries/countries.dart
@@ -69,3 +69,5 @@ class Country extends Equatable {
   @override
   List<Object?> get props => [name, code];
 }
+
+const mexico = Country(name: 'Mexico', code: 'MX');

--- a/lib/features/countries/countries_notifier.dart
+++ b/lib/features/countries/countries_notifier.dart
@@ -25,9 +25,7 @@ class CountriesNotifier extends StateNotifier<List<Country>> {
     );
   }
 
-  Future<Country> add(String code, String name) async {
-    final country = Country(code: code, name: name);
-
+  Future<Country> add(Country country) async {
     state = [...state, country];
     await _save();
     return country;

--- a/lib/features/countries/countries_page.dart
+++ b/lib/features/countries/countries_page.dart
@@ -1,6 +1,7 @@
 import 'package:didpay/features/countries/countries.dart';
 import 'package:didpay/features/countries/countries_notifier.dart';
 import 'package:didpay/features/payment/payment_amount_page.dart';
+import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/header.dart';
@@ -36,8 +37,10 @@ class CountriesPage extends HookConsumerWidget {
                   : () => Navigator.of(context).push(
                         MaterialPageRoute(
                           builder: (context) => PaymentAmountPage(
-                            transactionType: TransactionType.send,
-                            country: country.value,
+                            paymentState: PaymentState(
+                              transactionType: TransactionType.deposit,
+                              selectedCountry: country.value,
+                            ),
                           ),
                         ),
                       ),

--- a/lib/features/feature_flags/feature_flag.dart
+++ b/lib/features/feature_flags/feature_flag.dart
@@ -20,13 +20,12 @@ class FeatureFlag extends Equatable {
   Map<String, dynamic> toJson() =>
       {'name': name, 'description': description, 'isEnabled': isEnabled};
 
-  FeatureFlag copyWith({String? name, String? description, bool? isEnabled}) {
-    return FeatureFlag(
-      name: name ?? this.name,
-      description: description ?? this.description,
-      isEnabled: isEnabled ?? this.isEnabled,
-    );
-  }
+  FeatureFlag copyWith({String? name, String? description, bool? isEnabled}) =>
+      FeatureFlag(
+        name: name ?? this.name,
+        description: description ?? this.description,
+        isEnabled: isEnabled ?? this.isEnabled,
+      );
 
   @override
   List<Object?> get props => [name, description, isEnabled];

--- a/lib/features/feature_flags/feature_flag.dart
+++ b/lib/features/feature_flags/feature_flag.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+class FeatureFlag extends Equatable {
+  final String name;
+  final String description;
+  final bool isEnabled;
+
+  const FeatureFlag({
+    required this.name,
+    required this.description,
+    this.isEnabled = false,
+  });
+
+  factory FeatureFlag.fromJson(Map<String, dynamic> json) => FeatureFlag(
+        name: json['name'],
+        description: json['description'],
+        isEnabled: json['isEnabled'],
+      );
+
+  Map<String, dynamic> toJson() =>
+      {'name': name, 'description': description, 'isEnabled': isEnabled};
+
+  FeatureFlag copyWith({String? name, String? description, bool? isEnabled}) {
+    return FeatureFlag(
+      name: name ?? this.name,
+      description: description ?? this.description,
+      isEnabled: isEnabled ?? this.isEnabled,
+    );
+  }
+
+  @override
+  List<Object?> get props => [name, description, isEnabled];
+}
+
+const lucidMode = FeatureFlag(
+  name: 'Lucid mode',
+  description: 'Access all your PFI offerings',
+);

--- a/lib/features/feature_flags/feature_flags_notifier.dart
+++ b/lib/features/feature_flags/feature_flags_notifier.dart
@@ -1,0 +1,55 @@
+import 'package:didpay/features/feature_flags/feature_flag.dart';
+import 'package:didpay/shared/serializer.dart';
+import 'package:hive/hive.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+final featureFlagsProvider =
+    StateNotifierProvider<FeatureFlagsNotifier, List<FeatureFlag>>(
+  (ref) => throw UnimplementedError(),
+);
+
+class FeatureFlagsNotifier extends StateNotifier<List<FeatureFlag>> {
+  static const String storageKey = 'feature_flags';
+  final Box box;
+
+  FeatureFlagsNotifier._(this.box, List<FeatureFlag> state) : super(state);
+
+  static Future<FeatureFlagsNotifier> create(
+    Box box,
+  ) async {
+    final List<dynamic> flagsJson = await box.get(storageKey) ?? [];
+
+    return FeatureFlagsNotifier._(
+      box,
+      Serializer.deserializeList(flagsJson, FeatureFlag.fromJson),
+    );
+  }
+
+  Future<FeatureFlag> add(FeatureFlag flag) async {
+    state = [
+      ...state,
+      FeatureFlag(name: flag.name, description: flag.description),
+    ];
+
+    await _save();
+    return flag;
+  }
+
+  Future<void> remove(FeatureFlag flag) async {
+    state = state.where((elem) => elem != flag).toList();
+    await _save();
+  }
+
+  Future<void> toggleFlag(FeatureFlag flag) async {
+    state = state
+        .map((f) => f == flag ? f.copyWith(isEnabled: !f.isEnabled) : f)
+        .toList();
+    await _save();
+  }
+
+  Future<void> _save() async {
+    final featureFlags =
+        Serializer.serializeList(state, (flag) => flag.toJson());
+    await box.put(storageKey, featureFlags);
+  }
+}

--- a/lib/features/feature_flags/lucid/lucid_offerings_page.dart
+++ b/lib/features/feature_flags/lucid/lucid_offerings_page.dart
@@ -46,8 +46,6 @@ class LucidOfferingsPage extends HookConsumerWidget {
                 )
                 .toList();
 
-            print(offerings);
-
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/lib/features/feature_flags/lucid/lucid_offerings_page.dart
+++ b/lib/features/feature_flags/lucid/lucid_offerings_page.dart
@@ -1,0 +1,144 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:didpay/features/payment/payment_amount_page.dart';
+import 'package:didpay/features/payment/payment_state.dart';
+import 'package:didpay/features/pfis/pfi.dart';
+import 'package:didpay/features/pfis/pfis_notifier.dart';
+import 'package:didpay/features/tbdex/tbdex_service.dart';
+import 'package:didpay/features/transaction/transaction.dart';
+import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/async/async_error_widget.dart';
+import 'package:didpay/shared/async/async_loading_widget.dart';
+import 'package:didpay/shared/header.dart';
+import 'package:didpay/shared/next_button.dart';
+import 'package:didpay/shared/theme/grid.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tbdex/tbdex.dart';
+
+class LucidOfferingsPage extends HookConsumerWidget {
+  const LucidOfferingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedPfi = useState<Pfi?>(null);
+    final selectedOffering = useState<Offering?>(null);
+    final offerings =
+        useState<AsyncValue<Map<Pfi, List<Offering>>>>(const AsyncLoading());
+
+    useEffect(
+      () {
+        Future.microtask(() async => _getOfferings(ref, offerings));
+        return null;
+      },
+      [],
+    );
+
+    return Scaffold(
+      appBar: AppBar(),
+      body: SafeArea(
+        child: offerings.value.when(
+          data: (offeringsMap) {
+            final offerings = offeringsMap.entries
+                .expand(
+                  (entry) => entry.value
+                      .map((offering) => MapEntry(entry.key, offering)),
+                )
+                .toList();
+
+            print(offerings);
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Header(
+                  title: Loc.of(context).lucidMode,
+                  subtitle: Loc.of(context).selectFromUnfilteredList,
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: offerings.length,
+                    itemBuilder: (context, index) {
+                      final entry = offerings[index];
+                      final pfi = entry.key;
+                      final offering = entry.value;
+                      final isSelected = selectedOffering.value?.metadata.id ==
+                          offering.metadata.id;
+
+                      return ListTile(
+                        leading: Container(
+                          width: Grid.md,
+                          height: Grid.md,
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.surface,
+                            borderRadius: BorderRadius.circular(Grid.xxs),
+                          ),
+                          child: const Center(child: Icon(Icons.attach_money)),
+                        ),
+                        title: Text(
+                          '${offering.data.payin.currencyCode} → ${offering.data.payout.currencyCode}',
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                        subtitle: AutoSizeText(
+                          offering.metadata.from,
+                          style: Theme.of(context).textTheme.bodySmall,
+                          maxLines: 1,
+                        ),
+                        onTap: () {
+                          selectedOffering.value = offering;
+                          selectedPfi.value = pfi;
+                        },
+                        trailing: isSelected
+                            ? Icon(
+                                Icons.check,
+                                color: Theme.of(context).colorScheme.primary,
+                              )
+                            : null,
+                      );
+                    },
+                  ),
+                ),
+                NextButton(
+                  onPressed: selectedOffering.value == null
+                      ? null
+                      : () => Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (context) => PaymentAmountPage(
+                                paymentState: PaymentState(
+                                  transactionType: TransactionType.send,
+                                  selectedOffering: selectedOffering.value,
+                                  selectedPfi: selectedPfi.value,
+                                ),
+                              ),
+                            ),
+                          ),
+                ),
+              ],
+            );
+          },
+          loading: () =>
+              AsyncLoadingWidget(text: Loc.of(context).fetchingOfferings),
+          error: (error, stackTrace) => AsyncErrorWidget(
+            text: error.toString(),
+            onRetry: () => _getOfferings(ref, offerings),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _getOfferings(
+    WidgetRef ref,
+    ValueNotifier<AsyncValue<Map<Pfi, List<Offering>>>> state,
+  ) async {
+    state.value = const AsyncLoading();
+    try {
+      await ref
+          .read(tbdexServiceProvider)
+          .getOfferings(ref.read(pfisProvider))
+          .then((offerings) => state.value = AsyncData(offerings));
+    } on Exception catch (e) {
+      state.value = AsyncError(e, StackTrace.current);
+    }
+  }
+}

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:didpay/features/account/account_balance_card.dart';
 import 'package:didpay/features/did/did_provider.dart';
 import 'package:didpay/features/payment/payment_amount_page.dart';
+import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/pfis/pfis_add_page.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
@@ -149,7 +150,9 @@ class HomePage extends HookConsumerWidget {
                   builder: (context) => ref.read(pfisProvider).isEmpty
                       ? const PfisAddPage()
                       : const PaymentAmountPage(
-                          transactionType: TransactionType.deposit,
+                          paymentState: PaymentState(
+                            transactionType: TransactionType.deposit,
+                          ),
                         ),
                 ),
               ),

--- a/lib/features/payment/payment_state.dart
+++ b/lib/features/payment/payment_state.dart
@@ -1,4 +1,5 @@
 import 'package:decimal/decimal.dart';
+import 'package:didpay/features/countries/countries.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:tbdex/tbdex.dart';
@@ -13,6 +14,7 @@ class PaymentState {
   final Decimal? payinAmount;
   final Decimal? payoutAmount;
   final Decimal? exchangeRate;
+  final Country? selectedCountry;
   final Pfi? selectedPfi;
   final Offering? selectedOffering;
   final PayinMethod? selectedPayinMethod;
@@ -33,6 +35,7 @@ class PaymentState {
     this.payinAmount,
     this.payoutAmount,
     this.exchangeRate,
+    this.selectedCountry,
     this.selectedPfi,
     this.selectedOffering,
     this.selectedPayinMethod,
@@ -54,6 +57,7 @@ class PaymentState {
     Decimal? payinAmount,
     Decimal? payoutAmount,
     Decimal? exchangeRate,
+    Country? selectedCountry,
     Pfi? selectedPfi,
     Offering? selectedOffering,
     PayinMethod? selectedPayinMethod,
@@ -74,6 +78,7 @@ class PaymentState {
       payinAmount: payinAmount ?? this.payinAmount,
       payoutAmount: payoutAmount ?? this.payoutAmount,
       exchangeRate: exchangeRate ?? this.exchangeRate,
+      selectedCountry: selectedCountry ?? this.selectedCountry,
       selectedPfi: selectedPfi ?? this.selectedPfi,
       selectedOffering: selectedOffering ?? this.selectedOffering,
       selectedPayinMethod: selectedPayinMethod ?? this.selectedPayinMethod,

--- a/lib/features/send/send_page.dart
+++ b/lib/features/send/send_page.dart
@@ -1,5 +1,8 @@
 import 'package:didpay/features/account/account_balance_notifier.dart';
 import 'package:didpay/features/countries/countries_page.dart';
+import 'package:didpay/features/feature_flags/feature_flag.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
+import 'package:didpay/features/feature_flags/lucid/lucid_offerings_page.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/send/send_details_page.dart';
 import 'package:didpay/l10n/app_localizations.dart';
@@ -19,6 +22,7 @@ class SendPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final pfis = ref.watch(pfisProvider);
     final accountBalance = ref.watch(accountBalanceProvider(pfis));
+    final featureFlags = ref.watch(featureFlagsProvider);
 
     final amount = useState('0');
     final keyPress = useState(NumberKeyPress(0, ''));
@@ -26,18 +30,7 @@ class SendPage extends HookConsumerWidget {
     final sendCurrency = accountBalance.asData?.value?.currencyCode ?? '';
 
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.language, size: Grid.md),
-          onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const CountriesPage(),
-              ),
-            );
-          },
-        ),
-      ),
+      appBar: _buildAppBar(context, featureFlags),
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -91,6 +84,40 @@ class SendPage extends HookConsumerWidget {
       ),
     );
   }
+
+  AppBar _buildAppBar(BuildContext context, List<FeatureFlag> featureFlags) =>
+      AppBar(
+        leading: Padding(
+          padding: const EdgeInsets.only(left: Grid.xxs),
+          child: IconButton(
+            icon: const Icon(Icons.language, size: Grid.lg),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const CountriesPage(),
+                ),
+              );
+            },
+          ),
+        ),
+        actions: featureFlags.any(
+          (flag) => flag.name == Loc.of(context).lucidMode && flag.isEnabled,
+        )
+            ? [
+                Padding(
+                  padding: const EdgeInsets.only(right: Grid.xxs),
+                  child: IconButton(
+                    icon: const Icon(Icons.deblur, size: Grid.lg),
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const LucidOfferingsPage(),
+                      ),
+                    ),
+                  ),
+                ),
+              ]
+            : null,
+      );
 
   Widget _buildCurrency(BuildContext context, String sendCurrency) => Padding(
         padding: const EdgeInsets.symmetric(horizontal: Grid.xxs),

--- a/lib/features/vcs/vcs_notifier.dart
+++ b/lib/features/vcs/vcs_notifier.dart
@@ -32,6 +32,6 @@ class VcsNotifier extends StateNotifier<List<String>> {
   }
 
   Future<void> _save() async {
-    await box.put('vcs', state);
+    await box.put(storageKey, state);
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -144,5 +144,8 @@
     "fetchingTransactions": "Fetching transactions...",
     "scan": "Scan",
     "cameraUnavailable": "Camera unavailable",
-    "dontKnowTheirDid": "Don't know their DID? Scan their DID QR code instead"
+    "dontKnowTheirDid": "Don't know their DID? Scan their DID QR code instead",
+    "featureFlags": "Feature flags",
+    "lucidMode": "Lucid mode",
+    "selectFromUnfilteredList": "Select from an unfiltered list of all your PFI offerings."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -774,6 +774,24 @@ abstract class Loc {
   /// In en, this message translates to:
   /// **'Don\'t know their DID? Scan their DID QR code instead'**
   String get dontKnowTheirDid;
+
+  /// No description provided for @featureFlags.
+  ///
+  /// In en, this message translates to:
+  /// **'Feature flags'**
+  String get featureFlags;
+
+  /// No description provided for @lucidMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Lucid mode'**
+  String get lucidMode;
+
+  /// No description provided for @selectFromUnfilteredList.
+  ///
+  /// In en, this message translates to:
+  /// **'Select from an unfiltered list of all your PFI offerings.'**
+  String get selectFromUnfilteredList;
 }
 
 class _LocDelegate extends LocalizationsDelegate<Loc> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -353,4 +353,13 @@ class LocEn extends Loc {
 
   @override
   String get dontKnowTheirDid => 'Don\'t know their DID? Scan their DID QR code instead';
+
+  @override
+  String get featureFlags => 'Feature flags';
+
+  @override
+  String get lucidMode => 'Lucid mode';
+
+  @override
+  String get selectFromUnfilteredList => 'Select from an unfiltered list of all your PFI offerings.';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,10 @@
 import 'package:didpay/features/app/app.dart';
+import 'package:didpay/features/countries/countries.dart';
 import 'package:didpay/features/countries/countries_notifier.dart';
 import 'package:didpay/features/did/did_provider.dart';
 import 'package:didpay/features/did/did_storage_service.dart';
+import 'package:didpay/features/feature_flags/feature_flag.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/pfis/pfis_service.dart';
 import 'package:didpay/features/vcs/vcs_notifier.dart';
@@ -51,16 +54,21 @@ Future<List<Override>> notifierOverrides() async {
   final countriesBox = await Hive.openBox(CountriesNotifier.storageKey);
   final countriesNotifier = await CountriesNotifier.create(countriesBox);
 
-  if (countriesBox.isEmpty) {
-    await countriesNotifier.add('MX', 'Mexico');
-  }
+  if (countriesBox.isEmpty) await countriesNotifier.add(mexico);
 
   final vcsBox = await Hive.openBox(VcsNotifier.storageKey);
   final vcsNotifier = await VcsNotifier.create(vcsBox);
+
+  final featureFlagsBox = await Hive.openBox(FeatureFlagsNotifier.storageKey);
+  final featureFlagsNotifier =
+      await FeatureFlagsNotifier.create(featureFlagsBox);
+
+  if (featureFlagsBox.isEmpty) await featureFlagsNotifier.add(lucidMode);
 
   return [
     pfisProvider.overrideWith((ref) => pfisNofitier),
     countriesProvider.overrideWith((ref) => countriesNotifier),
     vcsProvider.overrideWith((ref) => vcsNotifier),
+    featureFlagsProvider.overrideWith((ref) => featureFlagsNotifier),
   ];
 }

--- a/test/features/account/account_page_test.dart
+++ b/test/features/account/account_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:didpay/features/account/account_page.dart';
 import 'package:didpay/features/did/did_qr_tabs.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/vcs/vcs_notifier.dart';
 import 'package:flutter/material.dart';
@@ -13,11 +14,13 @@ void main() async {
 
   late MockPfisNotifier mockPfisNotifier;
   late MockVcsNotifier mockVcsNotifier;
+  late MockFeatureFlagsNotifier mockFeatureFlagsNotifier;
 
   group('AccountPage', () {
     setUp(() {
       mockPfisNotifier = MockPfisNotifier([]);
       mockVcsNotifier = MockVcsNotifier([]);
+      mockFeatureFlagsNotifier = MockFeatureFlagsNotifier([]);
     });
 
     Widget accountPageTestWidget() => WidgetHelpers.testableWidget(
@@ -25,6 +28,8 @@ void main() async {
           overrides: [
             pfisProvider.overrideWith((ref) => mockPfisNotifier),
             vcsProvider.overrideWith((ref) => mockVcsNotifier),
+            featureFlagsProvider
+                .overrideWith((ref) => mockFeatureFlagsNotifier),
           ],
         );
 
@@ -55,8 +60,10 @@ void main() async {
     testWidgets('should show no credentials issued yet tile', (tester) async {
       await tester.pumpWidget(accountPageTestWidget());
 
-      expect(find.widgetWithText(ListTile, 'No credentials issued yet'),
-          findsOneWidget,);
+      expect(
+        find.widgetWithText(ListTile, 'No credentials issued yet'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('should show DidQrTabs on tap of qr icon', (tester) async {

--- a/test/features/app/app_tabs_test.dart
+++ b/test/features/app/app_tabs_test.dart
@@ -3,6 +3,7 @@ import 'package:didpay/features/account/account_balance_notifier.dart';
 import 'package:didpay/features/account/account_page.dart';
 import 'package:didpay/features/app/app_tabs.dart';
 import 'package:didpay/features/did/did_provider.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/home/home_page.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
@@ -27,11 +28,13 @@ void main() async {
   late MockTbdexService mockTbdexService;
   late MockPfisNotifier mockPfisNotifier;
   late MockVcsNotifier mockVcsNotifier;
+  late MockFeatureFlagsNotifier mockFeatureFlagsNotifier;
 
   setUp(() {
     mockTbdexService = MockTbdexService();
     mockPfisNotifier = MockPfisNotifier([pfi]);
     mockVcsNotifier = MockVcsNotifier([]);
+    mockFeatureFlagsNotifier = MockFeatureFlagsNotifier([]);
 
     when(
       () => mockTbdexService.getExchanges(did, [pfi]),
@@ -53,6 +56,8 @@ void main() async {
             tbdexServiceProvider.overrideWith((ref) => mockTbdexService),
             pfisProvider.overrideWith((ref) => mockPfisNotifier),
             vcsProvider.overrideWith((ref) => mockVcsNotifier),
+            featureFlagsProvider
+                .overrideWith((ref) => mockFeatureFlagsNotifier),
             transactionProvider.overrideWith(MockTransactionNotifier.new),
             accountBalanceProvider
                 .overrideWith(() => MockAccountBalanceNotifier(accountBalance)),

--- a/test/features/app/app_test.dart
+++ b/test/features/app/app_test.dart
@@ -1,6 +1,7 @@
 import 'package:didpay/features/account/account_balance.dart';
 import 'package:didpay/features/app/app_tabs.dart';
 import 'package:didpay/features/did/did_provider.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/tbdex/tbdex_service.dart';
@@ -20,11 +21,13 @@ void main() async {
   late MockTbdexService mockTbdexService;
   late MockPfisNotifier mockPfisNotifier;
   late MockVcsNotifier mockVcsNotifier;
+  late MockFeatureFlagsNotifier mockFeatureFlagsNotifier;
 
   setUp(() {
     mockTbdexService = MockTbdexService();
     mockPfisNotifier = MockPfisNotifier([pfi]);
     mockVcsNotifier = MockVcsNotifier([]);
+    mockFeatureFlagsNotifier = MockFeatureFlagsNotifier([]);
 
     when(
       () => mockTbdexService.getExchanges(did, [pfi]),
@@ -47,6 +50,7 @@ void main() async {
           tbdexServiceProvider.overrideWith((ref) => mockTbdexService),
           pfisProvider.overrideWith((ref) => mockPfisNotifier),
           vcsProvider.overrideWith((ref) => mockVcsNotifier),
+          featureFlagsProvider.overrideWith((ref) => mockFeatureFlagsNotifier),
           transactionProvider.overrideWith(MockTransactionNotifier.new),
         ],
       ),

--- a/test/features/countries/countries_notifier_test.dart
+++ b/test/features/countries/countries_notifier_test.dart
@@ -16,8 +16,8 @@ void main() {
     test('should create and load initial list', () async {
       final initialCountries = [const Country(name: 'Mexico', code: 'MXN')];
 
-      when(() => mockBox.get(CountriesNotifier.storageKey))
-          .thenReturn(initialCountries.map((pfi) => pfi.toJson()).toList());
+      when(() => mockBox.get(CountriesNotifier.storageKey)).thenReturn(
+          initialCountries.map((country) => country.toJson()).toList(),);
       final notifier = await CountriesNotifier.create(mockBox);
 
       expect(notifier.state, initialCountries);
@@ -28,8 +28,8 @@ void main() {
       final initialCountries = [const Country(name: 'Mexico', code: 'MXN')];
       const newCountry = Country(name: 'United States', code: 'USD');
 
-      when(() => mockBox.get(CountriesNotifier.storageKey))
-          .thenReturn(initialCountries.map((pfi) => pfi.toJson()).toList());
+      when(() => mockBox.get(CountriesNotifier.storageKey)).thenReturn(
+          initialCountries.map((country) => country.toJson()).toList(),);
       when(
         () => mockBox.put(
           CountriesNotifier.storageKey,
@@ -39,7 +39,7 @@ void main() {
 
       final notifier = await CountriesNotifier.create(mockBox);
 
-      final addedCountry = await notifier.add(newCountry.code, newCountry.name);
+      final addedCountry = await notifier.add(newCountry);
 
       expect(notifier.state, [...initialCountries, newCountry]);
       expect(addedCountry, newCountry);
@@ -59,8 +59,8 @@ void main() {
       final initialCountries = [const Country(name: 'Mexico', code: 'MXN')];
       final countryToRemove = initialCountries.first;
 
-      when(() => mockBox.get(CountriesNotifier.storageKey))
-          .thenReturn(initialCountries.map((pfi) => pfi.toJson()).toList());
+      when(() => mockBox.get(CountriesNotifier.storageKey)).thenReturn(
+          initialCountries.map((country) => country.toJson()).toList(),);
       when(() => mockBox.put(CountriesNotifier.storageKey, any()))
           .thenAnswer((_) async {});
 

--- a/test/features/feature_flags/feature_flags_notifier_test.dart
+++ b/test/features/feature_flags/feature_flags_notifier_test.dart
@@ -1,0 +1,83 @@
+import 'package:didpay/features/feature_flags/feature_flag.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../helpers/mocks.dart';
+
+void main() {
+  late MockBox mockBox;
+
+  setUp(() {
+    mockBox = MockBox();
+  });
+
+  group('FeatureFlagsNotifier', () {
+    test('should create and load initial list', () async {
+      final initialFeatureFlags = [
+        const FeatureFlag(name: 'test', description: 'test flag'),
+      ];
+
+      when(() => mockBox.get(FeatureFlagsNotifier.storageKey)).thenReturn(
+        initialFeatureFlags.map((flag) => flag.toJson()).toList(),
+      );
+      final notifier = await FeatureFlagsNotifier.create(mockBox);
+
+      expect(notifier.state, initialFeatureFlags);
+      verify(() => mockBox.get(FeatureFlagsNotifier.storageKey)).called(1);
+    });
+
+    test('should add a new FeatureFlag', () async {
+      final initialFeatureFlags = [
+        const FeatureFlag(name: 'test', description: 'test flag'),
+      ];
+      const newFeatureFlag =
+          FeatureFlag(name: 'new test', description: 'new test flag');
+
+      when(() => mockBox.get(FeatureFlagsNotifier.storageKey)).thenReturn(
+          initialFeatureFlags.map((flag) => flag.toJson()).toList(),);
+      when(
+        () => mockBox.put(
+          FeatureFlagsNotifier.storageKey,
+          any<List<Map<String, dynamic>>>(),
+        ),
+      ).thenAnswer((_) async {});
+
+      final notifier = await FeatureFlagsNotifier.create(mockBox);
+
+      final addedFeatureFlag = await notifier.add(newFeatureFlag);
+
+      expect(notifier.state, [...initialFeatureFlags, newFeatureFlag]);
+      expect(addedFeatureFlag, newFeatureFlag);
+
+      verify(
+        () => mockBox.put(
+          FeatureFlagsNotifier.storageKey,
+          [
+            ...initialFeatureFlags.map((flag) => flag.toJson()),
+            newFeatureFlag.toJson(),
+          ],
+        ),
+      ).called(1);
+    });
+
+    test('should remove a FeatureFlag', () async {
+      final initialFeatureFlags = [
+        const FeatureFlag(name: 'test', description: 'test flag'),
+      ];
+      final featureFlagToRemove = initialFeatureFlags.first;
+
+      when(() => mockBox.get(FeatureFlagsNotifier.storageKey)).thenReturn(
+        initialFeatureFlags.map((flag) => flag.toJson()).toList(),
+      );
+      when(() => mockBox.put(FeatureFlagsNotifier.storageKey, any()))
+          .thenAnswer((_) async {});
+
+      final notifier = await FeatureFlagsNotifier.create(mockBox);
+      await notifier.remove(featureFlagToRemove);
+
+      expect(notifier.state, []);
+      verify(() => mockBox.put(FeatureFlagsNotifier.storageKey, [])).called(1);
+    });
+  });
+}

--- a/test/features/feature_flags/lucid/lucid_offerings_page_test.dart
+++ b/test/features/feature_flags/lucid/lucid_offerings_page_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
+import 'package:didpay/features/feature_flags/lucid/lucid_offerings_page.dart';
+import 'package:didpay/features/pfis/pfi.dart';
+import 'package:didpay/features/pfis/pfis_notifier.dart';
+import 'package:didpay/features/tbdex/tbdex_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tbdex/tbdex.dart';
+
+import '../../../helpers/mocks.dart';
+import '../../../helpers/widget_helpers.dart';
+
+void main() {
+  const jsonString =
+      r'''[{"metadata":{"kind":"offering","from":"did:web:localhost%3A8892:ingress","id":"offering_01hv22zfv1eptadkm92v278gh9","protocol":"1.0","createdAt":"2024-04-12T20:57:11Z","updatedAt":"2024-04-12T20:57:11Z"},"data":{"description":"MXN for USD","payoutUnitsPerPayinUnit":"16.34","payin":{"currencyCode":"USD","methods":[{"kind":"STORED_BALANCE","name":"Account balance"}]},"payout":{"currencyCode":"MXN","methods":[{"kind":"SPEI","estimatedSettlementTime":300,"name":"SPEI","requiredPaymentDetails":{"$schema":"http://json-schema.org/draft-07/schema#","additionalProperties":false,"properties":{"clabe":{"type":"string"},"fullName":{"type":"string"}},"required":["clabe","fullName"]}}]}},"signature":"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6bG9jYWxob3N0JTNBODg5MjppbmdyZXNzIzAifQ..le65W3WyI2UKMJojADv_lTQixt0wDmnMMBVaWC_2BaYVQfe8HY3gQyPqbI4dT-iDNRjg_EdlCvTiEzANfp0lDw"}]''';
+  const pfi = Pfi(did: 'did:web:x%3A8892:ingress');
+
+  final jsonList = jsonDecode(jsonString) as List<dynamic>;
+  final offerings = {
+    pfi: [Offering.fromJson(jsonList[0])],
+  };
+  late MockTbdexService mockTbdexService;
+  late MockPfisNotifier mockPfisNotifier;
+  late MockFeatureFlagsNotifier mockFeatureFlagsNotifier;
+
+  setUp(() {
+    mockTbdexService = MockTbdexService();
+    mockPfisNotifier = MockPfisNotifier([pfi]);
+    mockFeatureFlagsNotifier = MockFeatureFlagsNotifier([]);
+
+    when(
+      () => mockTbdexService.getOfferings([pfi]),
+    ).thenAnswer((_) async => offerings);
+  });
+
+  group('LucidOfferingsPage', () {
+    Widget lucidOfferingsPageTestWidget() => WidgetHelpers.testableWidget(
+          child: const LucidOfferingsPage(),
+          overrides: [
+            tbdexServiceProvider.overrideWith((ref) => mockTbdexService),
+            pfisProvider.overrideWith((ref) => mockPfisNotifier),
+            featureFlagsProvider
+                .overrideWith((ref) => mockFeatureFlagsNotifier),
+          ],
+        );
+
+    testWidgets('should show header', (tester) async {
+      await tester.pumpWidget(lucidOfferingsPageTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Lucid mode'), findsOneWidget);
+      expect(
+        find.text('Select from an unfiltered list of all your PFI offerings.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('should show loading indicator while fetching', (tester) async {
+      await tester.pumpWidget(lucidOfferingsPageTestWidget());
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('should show offerings', (tester) async {
+      await tester.pumpWidget(lucidOfferingsPageTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(
+        find.widgetWithText(ListTile, 'USD → MXN'),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/test/features/payment/payment_amount_page_test.dart
+++ b/test/features/payment/payment_amount_page_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:didpay/features/payin/payin.dart';
 import 'package:didpay/features/payment/payment_amount_page.dart';
 import 'package:didpay/features/payment/payment_fee_details.dart';
+import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/payout/payout.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
@@ -40,7 +41,8 @@ void main() {
   group('PaymentAmountPage', () {
     Widget paymentAmountPageTestWidget() => WidgetHelpers.testableWidget(
           child: const PaymentAmountPage(
-            transactionType: TransactionType.deposit,
+            paymentState:
+                PaymentState(transactionType: TransactionType.deposit),
           ),
           overrides: [
             tbdexServiceProvider.overrideWith((ref) => mockTbdexService),

--- a/test/features/send/send_page_test.dart
+++ b/test/features/send/send_page_test.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:didpay/features/account/account_balance.dart';
 import 'package:didpay/features/account/account_balance_notifier.dart';
 import 'package:didpay/features/did/did_provider.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/send/send_details_page.dart';
@@ -23,6 +24,12 @@ void main() async {
       AccountBalance(total: '101', currencyCode: 'USD', balancesMap: {});
 
   late MockPfisNotifier mockPfisNotifier;
+  late MockFeatureFlagsNotifier mockFeatureFlagsNotifier;
+
+  setUp(() {
+    mockPfisNotifier = MockPfisNotifier([pfi]);
+    mockFeatureFlagsNotifier = MockFeatureFlagsNotifier([]);
+  });
 
   group('SendPage', () {
     Widget sendPageTestWidget() => WidgetHelpers.testableWidget(
@@ -30,14 +37,12 @@ void main() async {
           overrides: [
             didProvider.overrideWithValue(did),
             pfisProvider.overrideWith((ref) => mockPfisNotifier),
+            featureFlagsProvider
+                .overrideWith((ref) => mockFeatureFlagsNotifier),
             accountBalanceProvider
                 .overrideWith(() => MockAccountBalanceNotifier(accountBalance)),
           ],
         );
-
-    setUp(() {
-      mockPfisNotifier = MockPfisNotifier([pfi]);
-    });
 
     testWidgets('should show Number Pad', (tester) async {
       await tester.pumpWidget(sendPageTestWidget());

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -4,6 +4,8 @@ import 'package:didpay/features/account/account_balance.dart';
 import 'package:didpay/features/account/account_balance_notifier.dart';
 import 'package:didpay/features/countries/countries.dart';
 import 'package:didpay/features/countries/countries_notifier.dart';
+import 'package:didpay/features/feature_flags/feature_flag.dart';
+import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
 import 'package:didpay/features/pfis/pfis_service.dart';
@@ -46,6 +48,12 @@ class MockCountriesNotifier extends StateNotifier<List<Country>>
     with Mock
     implements CountriesNotifier {
   MockCountriesNotifier(super.state);
+}
+
+class MockFeatureFlagsNotifier extends StateNotifier<List<FeatureFlag>>
+    with Mock
+    implements FeatureFlagsNotifier {
+  MockFeatureFlagsNotifier(super.state);
 }
 
 class MockTransactionNotifier extends AutoDisposeFamilyAsyncNotifier<


### PR DESCRIPTION
- adds lucid mode: a developer setting to view every offering from all your pfis, regardless of if they are fully compatible with didpay
- adds `FeatureFlag` and `FeatureFlagsNotifier`


https://github.com/TBD54566975/didpay/assets/125412902/0b8f22b4-5b9e-4bdf-bf40-76a46c7dd840

 