### PR TITLE
feat: async safety

### DIFF
--- a/lib/features/dap/dap_qr_tile.dart
+++ b/lib/features/dap/dap_qr_tile.dart
@@ -5,15 +5,12 @@ import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:web5/web5.dart';
 
 class DapQrTile extends HookConsumerWidget {
   final TextEditingController dapTextController;
-  final ValueNotifier<String?>? errorText;
 
   const DapQrTile({
     required this.dapTextController,
-    this.errorText,
     super.key,
   });
 
@@ -45,13 +42,10 @@ class DapQrTile extends HookConsumerWidget {
             ? _scanQrCode(
                 context,
                 dapTextController,
-                errorText,
-                Loc.of(context).noDapQrCodeFound,
               )
             : _simulateScanQrCode(
                 context,
                 dapTextController,
-                errorText,
               ),
       ),
     );
@@ -60,8 +54,6 @@ class DapQrTile extends HookConsumerWidget {
   Future<void> _scanQrCode(
     BuildContext context,
     TextEditingController dapTextController,
-    ValueNotifier<String?>? errorText,
-    String errorMessage,
   ) async {
     final qrValue = await Navigator.of(context).push<String>(
       MaterialPageRoute(
@@ -69,16 +61,12 @@ class DapQrTile extends HookConsumerWidget {
       ),
     );
 
-    final isValid = qrValue != null &&
-        await DidResolver.resolve(qrValue).then((result) => !result.hasError());
-    dapTextController.text = isValid ? qrValue : '';
-    errorText?.value = isValid ? null : errorMessage;
+    dapTextController.text = qrValue ?? '';
   }
 
   Future<void> _simulateScanQrCode(
     BuildContext context,
     TextEditingController didTextController,
-    ValueNotifier<String?>? errorText,
   ) async {
     ScaffoldMessenger.of(context).removeCurrentSnackBar();
 
@@ -89,6 +77,5 @@ class DapQrTile extends HookConsumerWidget {
     );
 
     didTextController.text = '@moegrammer/didpay.me';
-    errorText?.value = null;
   }
 }

--- a/lib/features/feature_flags/lucid/lucid_offerings_page.dart
+++ b/lib/features/feature_flags/lucid/lucid_offerings_page.dart
@@ -28,7 +28,7 @@ class LucidOfferingsPage extends HookConsumerWidget {
 
     useEffect(
       () {
-        Future.microtask(() async => _getOfferings(ref, offerings));
+        Future.microtask(() async => _getOfferings(context, ref, offerings));
         return null;
       },
       [],
@@ -119,7 +119,7 @@ class LucidOfferingsPage extends HookConsumerWidget {
               LoadingMessage(message: Loc.of(context).fetchingOfferings),
           error: (error, stackTrace) => ErrorMessage(
             message: error.toString(),
-            onRetry: () => _getOfferings(ref, offerings),
+            onRetry: () => _getOfferings(context, ref, offerings),
           ),
         ),
       ),
@@ -127,18 +127,20 @@ class LucidOfferingsPage extends HookConsumerWidget {
   }
 
   Future<void> _getOfferings(
+    BuildContext context,
     WidgetRef ref,
     ValueNotifier<AsyncValue<Map<Pfi, List<Offering>>>> state,
   ) async {
     state.value = const AsyncLoading();
     try {
-      await ref
-          .read(tbdexServiceProvider)
-          .getOfferings(
+      final offerings = await ref.read(tbdexServiceProvider).getOfferings(
             const PaymentState(transactionType: TransactionType.send),
             ref.read(pfisProvider),
-          )
-          .then((offerings) => state.value = AsyncData(offerings));
+          );
+
+      if (context.mounted) {
+        state.value = AsyncData(offerings);
+      }
     } on Exception catch (e) {
       state.value = AsyncError(e, StackTrace.current);
     }

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -26,7 +26,7 @@ class HomePage extends HookConsumerWidget {
 
     useEffect(
       () {
-        Future.microtask(() async => _getExchanges(ref, exchanges));
+        Future.microtask(() async => _getExchanges(context, ref, exchanges));
         return null;
       },
       [],
@@ -86,7 +86,7 @@ class HomePage extends HookConsumerWidget {
                       Loc.of(context).startByAdding,
                     )
                   : RefreshIndicator(
-                      onRefresh: () async => _getExchanges(ref, state),
+                      onRefresh: () async => _getExchanges(context, ref, state),
                       child: ListView(
                         children: exchangeMap.entries
                             .expand(
@@ -185,7 +185,7 @@ class HomePage extends HookConsumerWidget {
                   Theme.of(context).colorScheme.secondaryContainer,
                 ),
               ),
-              onPressed: () async => _getExchanges(ref, state),
+              onPressed: () async => _getExchanges(context, ref, state),
               child: Text(Loc.of(context).tapToRetry),
             ),
           ],
@@ -193,15 +193,19 @@ class HomePage extends HookConsumerWidget {
       );
 
   Future<void> _getExchanges(
+    BuildContext context,
     WidgetRef ref,
     ValueNotifier<AsyncValue<Map<Pfi, List<String>>>> state,
   ) async {
     state.value = const AsyncLoading();
     try {
-      await ref
+      final exchanges = await ref
           .read(tbdexServiceProvider)
-          .getExchanges(ref.read(didProvider), ref.read(pfisProvider))
-          .then((exchanges) => state.value = AsyncData(exchanges));
+          .getExchanges(ref.read(didProvider), ref.read(pfisProvider));
+
+      if (context.mounted) {
+        state.value = AsyncData(exchanges);
+      }
     } on Exception catch (e) {
       state.value = AsyncError(e, StackTrace.current);
     }

--- a/lib/features/kcc/kcc_retrieval_page.dart
+++ b/lib/features/kcc/kcc_retrieval_page.dart
@@ -28,7 +28,9 @@ class KccRetrievalPage extends HookConsumerWidget {
 
     useEffect(
       () {
-        Future.microtask(() async => _pollForCredential(ref, credential));
+        Future.microtask(
+          () async => _pollForCredential(context, ref, credential),
+        );
 
         return null;
       },
@@ -43,7 +45,7 @@ class KccRetrievalPage extends HookConsumerWidget {
               LoadingMessage(message: Loc.of(context).verifyingYourIdentity),
           error: (error, stackTrace) => ErrorMessage(
             message: error.toString(),
-            onRetry: () => _pollForCredential(ref, credential),
+            onRetry: () => _pollForCredential(context, ref, credential),
           ),
           data: (data) => Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -79,6 +81,7 @@ class KccRetrievalPage extends HookConsumerWidget {
   }
 
   Future<void> _pollForCredential(
+    BuildContext context,
     WidgetRef ref,
     ValueNotifier<AsyncValue<String>> state,
   ) async {
@@ -91,10 +94,11 @@ class KccRetrievalPage extends HookConsumerWidget {
             ref.read(didProvider),
           );
 
-      await ref
-          .read(vcsProvider.notifier)
-          .add(credential)
-          .then((credential) => state.value = AsyncData(credential));
+      if (context.mounted) {
+        final addedCredential =
+            await ref.read(vcsProvider.notifier).add(credential);
+        state.value = AsyncData(addedCredential);
+      }
     } on Exception catch (e) {
       state.value = AsyncError(e, StackTrace.current);
     }

--- a/lib/features/kcc/kcc_webview_page.dart
+++ b/lib/features/kcc/kcc_webview_page.dart
@@ -37,7 +37,7 @@ class KccWebviewPage extends HookConsumerWidget {
 
     useEffect(
       () {
-        Future.microtask(() async => _getIdvRequest(ref, idvRequest));
+        Future.microtask(() async => _getIdvRequest(context, ref, idvRequest));
         return null;
       },
       [],
@@ -55,7 +55,7 @@ class KccWebviewPage extends HookConsumerWidget {
         error: (error, stackTrace) => SafeArea(
           child: ErrorMessage(
             message: error.toString(),
-            onRetry: () => _getIdvRequest(ref, idvRequest),
+            onRetry: () => _getIdvRequest(context, ref, idvRequest),
           ),
         ),
         data: (data) {
@@ -95,15 +95,19 @@ class KccWebviewPage extends HookConsumerWidget {
   }
 
   Future<void> _getIdvRequest(
+    BuildContext context,
     WidgetRef ref,
     ValueNotifier<AsyncValue<IdvRequest>> state,
   ) async {
     state.value = const AsyncLoading();
     try {
-      await ref
+      final idvRequest = await ref
           .read(kccIssuanceProvider)
-          .getIdvRequest(pfi, ref.read(didProvider))
-          .then((idvRequest) => state.value = AsyncData(idvRequest));
+          .getIdvRequest(pfi, ref.read(didProvider));
+
+      if (context.mounted) {
+        state.value = AsyncData(idvRequest);
+      }
     } on Exception catch (e) {
       state.value = AsyncError(e, StackTrace.current);
     }

--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -66,13 +66,12 @@ class PaymentDetailsPage extends HookConsumerWidget {
     final shouldShowPaymentMethodSelector =
         !shouldShowPaymentTypeSelector || selectedPaymentType.value != null;
 
+    final isSendingRfq = rfq.value?.isLoading ?? false;
+
     return PopScope(
-      canPop: !(rfq.value?.isLoading ?? false),
+      canPop: !isSendingRfq,
       onPopInvoked: (_) {
-        if (rfq.value?.isLoading ?? false) {
-          rfq.value = null;
-          return;
-        }
+        if (isSendingRfq) rfq.value = null;
       },
       child: Scaffold(
         appBar: AppBar(),
@@ -128,20 +127,14 @@ class PaymentDetailsPage extends HookConsumerWidget {
                             ? null
                             : selectedPaymentMethod.value as PayoutMethod?,
                       ),
-                      onPaymentFormSubmit: (paymentState) async => _sendRfq(
+                      onPaymentFormSubmit: (paymentState) async =>
+                          _checkCredsAndSendRfq(
                         context,
                         ref,
                         paymentState,
+                        offeringCredentials,
                         rfq,
-                        claims: offeringCredentials.value,
                       ),
-                      //     _checkCredsAndSendRfq(
-                      //   context,
-                      //   ref,
-                      //   paymentState,
-                      //   offeringCredentials,
-                      //   rfq,
-                      // ),
                     ),
                   ],
                 ),

--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:didpay/features/did/did_provider.dart';
-// import 'package:didpay/features/kcc/kcc_consent_page.dart';
+import 'package:didpay/features/kcc/kcc_consent_page.dart';
 import 'package:didpay/features/payment/payment_method_operations.dart';
 import 'package:didpay/features/payment/payment_methods_page.dart';
 import 'package:didpay/features/payment/payment_review_page.dart';
@@ -8,13 +8,13 @@ import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/payment/payment_types_page.dart';
 import 'package:didpay/features/tbdex/tbdex_service.dart';
 import 'package:didpay/features/transaction/transaction.dart';
-// import 'package:didpay/features/vcs/vcs_notifier.dart';
+import 'package:didpay/features/vcs/vcs_notifier.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/error_message.dart';
 import 'package:didpay/shared/header.dart';
 import 'package:didpay/shared/json_schema_form.dart';
 import 'package:didpay/shared/loading_message.dart';
-// import 'package:didpay/shared/modal/modal_flow.dart';
+import 'package:didpay/shared/modal/modal_flow.dart';
 import 'package:didpay/shared/theme/grid.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -45,7 +45,13 @@ class PaymentDetailsPage extends HookConsumerWidget {
       () {
         paymentState.dap != null
             ? Future.microtask(
-                () async => _sendRfq(context, ref, paymentState, rfq),
+                () async => _checkCredsAndSendRfq(
+                  context,
+                  ref,
+                  paymentState,
+                  offeringCredentials,
+                  rfq,
+                ),
               )
             : selectedPaymentMethod.value =
                 (filteredPaymentMethods?.length ?? 0) <= 1
@@ -60,88 +66,86 @@ class PaymentDetailsPage extends HookConsumerWidget {
     final shouldShowPaymentMethodSelector =
         !shouldShowPaymentTypeSelector || selectedPaymentType.value != null;
 
-    return Scaffold(
-      appBar: rfq.value?.isLoading ?? false ? null : AppBar(),
-      body: SafeArea(
-        child: rfq.value != null
-            ? rfq.value!.when(
-                data: (_) => Container(),
-                loading: () => LoadingMessage(
-                  message: Loc.of(context).sendingYourRequest,
-                ),
-                error: (error, _) => ErrorMessage(
-                  message: error.toString(),
-                  onRetry: () => _sendRfq(
-                    context,
-                    ref,
-                    paymentState,
-                    rfq,
-                    claims: offeringCredentials.value,
+    return PopScope(
+      canPop: !(rfq.value?.isLoading ?? false),
+      onPopInvoked: (_) {
+        if (rfq.value?.isLoading ?? false) {
+          rfq.value = null;
+          return;
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(),
+        body: SafeArea(
+          child: rfq.value != null
+              ? rfq.value!.when(
+                  data: (_) => Container(),
+                  loading: () => LoadingMessage(
+                    message: Loc.of(context).sendingYourRequest,
                   ),
-                ),
-              )
-            : Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Header(
-                    title: paymentState.transactionType == TransactionType.send
-                        ? Loc.of(context).enterTheirPaymentDetails
-                        : Loc.of(context).enterYourPaymentDetails,
-                    subtitle: Loc.of(context).makeSureInfoIsCorrect,
+                  error: (error, _) => ErrorMessage(
+                    message: error.toString(),
+                    onRetry: () => _sendRfq(
+                      context,
+                      ref,
+                      paymentState,
+                      rfq,
+                      claims: offeringCredentials.value,
+                    ),
                   ),
-                  if (shouldShowPaymentTypeSelector)
-                    _buildPaymentTypeSelector(
+                )
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Header(
+                      title:
+                          paymentState.transactionType == TransactionType.send
+                              ? Loc.of(context).enterTheirPaymentDetails
+                              : Loc.of(context).enterYourPaymentDetails,
+                      subtitle: Loc.of(context).makeSureInfoIsCorrect,
+                    ),
+                    if (shouldShowPaymentTypeSelector)
+                      _buildPaymentTypeSelector(
+                        context,
+                        selectedPaymentType,
+                        paymentTypes,
+                      ),
+                    if (shouldShowPaymentMethodSelector)
+                      _buildPaymentMethodSelector(
+                        context,
+                        selectedPaymentMethod,
+                        filteredPaymentMethods,
+                      ),
+                    _buildPaymentForm(
                       context,
-                      selectedPaymentType,
-                      paymentTypes,
-                    ),
-                  if (shouldShowPaymentMethodSelector)
-                    _buildPaymentMethodSelector(
-                      context,
-                      selectedPaymentMethod,
-                      filteredPaymentMethods,
-                    ),
-                  _buildPaymentForm(
-                    context,
-                    paymentState.copyWith(
-                      selectedPayinMethod: paymentState.transactionType ==
-                              TransactionType.deposit
-                          ? selectedPaymentMethod.value as PayinMethod?
-                          : null,
-                      selectedPayoutMethod: paymentState.transactionType ==
-                              TransactionType.deposit
-                          ? null
-                          : selectedPaymentMethod.value as PayoutMethod?,
-                    ),
-                    onPaymentFormSubmit: (paymentState) async {
-                      await _sendRfq(
+                      paymentState.copyWith(
+                        selectedPayinMethod: paymentState.transactionType ==
+                                TransactionType.deposit
+                            ? selectedPaymentMethod.value as PayinMethod?
+                            : null,
+                        selectedPayoutMethod: paymentState.transactionType ==
+                                TransactionType.deposit
+                            ? null
+                            : selectedPaymentMethod.value as PayoutMethod?,
+                      ),
+                      onPaymentFormSubmit: (paymentState) async => _sendRfq(
                         context,
                         ref,
                         paymentState,
                         rfq,
                         claims: offeringCredentials.value,
-                      );
-                      // TODO(ethan-tbd): uncomment below to initiate KCC flow
-                      // await _hasRequiredVc(
+                      ),
+                      //     _checkCredsAndSendRfq(
                       //   context,
                       //   ref,
                       //   paymentState,
                       //   offeringCredentials,
-                      // ).then(
-                      //   (hasRequiredVc) async => !hasRequiredVc
-                      //       ? null
-                      //       : _sendRfq(
-                      //           context,
-                      //           ref,
-                      //           paymentState,
-                      //           rfq,
-                      //           claims: offeringCredentials.value,
-                      //         ),
-                      // );
-                    },
-                  ),
-                ],
-              ),
+                      //   rfq,
+                      // ),
+                    ),
+                  ],
+                ),
+        ),
       ),
     );
   }
@@ -289,6 +293,31 @@ class PaymentDetailsPage extends HookConsumerWidget {
           )
           .toList();
 
+  Future<void> _checkCredsAndSendRfq(
+    BuildContext context,
+    WidgetRef ref,
+    PaymentState paymentState,
+    ValueNotifier<List<String>?> offeringCredentials,
+    ValueNotifier<AsyncValue<Rfq>?> state,
+  ) async {
+    final hasRequiredVc = await _hasRequiredVc(
+      context,
+      ref,
+      paymentState,
+      offeringCredentials,
+    );
+
+    if (hasRequiredVc && context.mounted) {
+      await _sendRfq(
+        context,
+        ref,
+        paymentState,
+        state,
+        claims: offeringCredentials.value,
+      );
+    }
+  }
+
   Future<void> _sendRfq(
     BuildContext context,
     WidgetRef ref,
@@ -299,65 +328,62 @@ class PaymentDetailsPage extends HookConsumerWidget {
     state.value = const AsyncLoading();
 
     try {
-      await ref
-          .read(tbdexServiceProvider)
-          .sendRfq(
+      final rfq = await ref.read(tbdexServiceProvider).sendRfq(
             ref.read(didProvider),
             paymentState.copyWith(claims: claims),
-          )
-          .then(
-            (rfq) async => Navigator.of(context)
-                .push(
-              MaterialPageRoute(
-                builder: (context) => PaymentReviewPage(
-                  paymentState: paymentState.copyWith(
-                    exchangeId: rfq.metadata.id,
-                    claims: claims,
-                  ),
-                ),
-              ),
-            )
-                .then((_) {
-              if (context.mounted) state.value = null;
-            }),
           );
+
+      if (context.mounted && state.value != null) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => PaymentReviewPage(
+              paymentState: paymentState.copyWith(
+                exchangeId: rfq.metadata.id,
+                claims: claims,
+              ),
+            ),
+          ),
+        );
+
+        if (context.mounted) state.value = null;
+      }
     } on Exception catch (e) {
       state.value = AsyncError(e, StackTrace.current);
     }
   }
 
-  // Future<bool> _hasRequiredVc(
-  //   BuildContext context,
-  //   WidgetRef ref,
-  //   PaymentState paymentState,
-  //   ValueNotifier<List<String>?> offeringCredentials,
-  // ) async {
-  //   final presentationDefinition =
-  //       paymentState.selectedOffering?.data.requiredClaims;
-  //   final credentials =
-  //       presentationDefinition?.selectCredentials(ref.read(vcsProvider));
+  Future<bool> _hasRequiredVc(
+    BuildContext context,
+    WidgetRef ref,
+    PaymentState paymentState,
+    ValueNotifier<List<String>?> offeringCredentials,
+  ) async {
+    final presentationDefinition =
+        paymentState.selectedOffering?.data.requiredClaims;
+    final credentials =
+        presentationDefinition?.selectCredentials(ref.read(vcsProvider));
 
-  //   if (credentials == null && presentationDefinition == null) {
-  //     return true;
-  //   }
+    if (credentials == null && presentationDefinition == null) {
+      return true;
+    }
 
-  //   if (credentials != null && credentials.isNotEmpty) {
-  //     offeringCredentials.value = credentials;
-  //     return true;
-  //   }
+    if (credentials != null && credentials.isNotEmpty) {
+      offeringCredentials.value = credentials;
+      return true;
+    }
 
-  //   final issuedCredential = await Navigator.of(context).push(
-  //     MaterialPageRoute(
-  //       builder: (context) => ModalFlow(
-  //         initialWidget: KccConsentPage(pfi: paymentState.selectedPfi!),
-  //       ),
-  //       fullscreenDialog: true,
-  //     ),
-  //   );
+    final issuedCredential = await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => ModalFlow(
+          initialWidget: KccConsentPage(pfi: paymentState.selectedPfi!),
+        ),
+        fullscreenDialog: true,
+      ),
+    );
 
-  //   if (issuedCredential == null) return false;
+    if (issuedCredential == null) return false;
 
-  //   offeringCredentials.value = [issuedCredential as String];
-  //   return true;
-  // }
+    offeringCredentials.value = [issuedCredential as String];
+    return true;
+  }
 }

--- a/lib/features/payment/payment_link_webview_page.dart
+++ b/lib/features/payment/payment_link_webview_page.dart
@@ -38,10 +38,6 @@ class PaymentLinkWebviewPage extends HookConsumerWidget {
 
           c.loadUrl(urlRequest: URLRequest(url: WebUri(fullPath)));
         },
-        // onCloseWindow: (controller) async {
-        //   await onSubmit();
-        //   if (context.mounted) Navigator.of(context).pop();
-        // },
         onLoadStop: (controller, url) async {
           if (url == null) {
             return;

--- a/lib/features/pfis/pfis_add_page.dart
+++ b/lib/features/pfis/pfis_add_page.dart
@@ -41,7 +41,7 @@ class PfisAddPage extends HookConsumerWidget {
                   Expanded(
                     child: DidForm(
                       buttonTitle: Loc.of(context).add,
-                      onSubmit: (did) async => _addPfi(ref, did, pfi),
+                      onSubmit: (did) async => _addPfi(context, ref, did, pfi),
                     ),
                   ),
                 ],
@@ -51,6 +51,7 @@ class PfisAddPage extends HookConsumerWidget {
   }
 
   Future<void> _addPfi(
+    BuildContext context,
     WidgetRef ref,
     String did,
     ValueNotifier<AsyncValue<Pfi>?> state,
@@ -58,7 +59,10 @@ class PfisAddPage extends HookConsumerWidget {
     state.value = const AsyncLoading();
     try {
       final pfi = await ref.read(pfisProvider.notifier).add(did);
-      state.value = AsyncData(pfi);
+
+      if (context.mounted) {
+        state.value = AsyncData(pfi);
+      }
     } on Exception catch (e) {
       state.value = AsyncError(e, StackTrace.current);
     }

--- a/lib/features/send/send_page.dart
+++ b/lib/features/send/send_page.dart
@@ -49,23 +49,22 @@ class SendPage extends HookConsumerWidget {
                     child: DapForm(
                       buttonTitle: Loc.of(context).next,
                       dap: dap,
-                      onSubmit: (recipientDap, moneyAddresses) =>
-                          Navigator.of(context)
-                              .push(
-                        MaterialPageRoute(
-                          builder: (_) => PaymentAmountPage(
-                            paymentState: PaymentState(
-                              transactionType: TransactionType.send,
-                              dap: recipientDap,
-                              moneyAddresses: moneyAddresses,
+                      onSubmit: (recipientDap, moneyAddresses) async {
+                        await Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => PaymentAmountPage(
+                              paymentState: PaymentState(
+                                transactionType: TransactionType.send,
+                                dap: recipientDap,
+                                moneyAddresses: moneyAddresses,
+                              ),
                             ),
+                            fullscreenDialog: true,
                           ),
-                          fullscreenDialog: true,
-                        ),
-                      )
-                              .then((_) {
+                        );
+
                         if (context.mounted) dap.value = null;
-                      }),
+                      },
                     ),
                   ),
                 ],

--- a/lib/shared/modal/modal_remove_item.dart
+++ b/lib/shared/modal/modal_remove_item.dart
@@ -54,8 +54,12 @@ class ModalRemoveItem {
                     ),
                   ),
                 ),
-                onTap: () async =>
-                    onRemove().then((_) => Navigator.pop(context)),
+                onTap: () async {
+                  await onRemove();
+                  if (context.mounted) {
+                    Navigator.pop(context);
+                  }
+                },
               ),
               Divider(
                 color: Theme.of(context)


### PR DESCRIPTION
- ensures that no `ValueNotifier` hooks are being updated after they have been unmounted
- removes uses of `then()`, especially in combination with `await`
- allow "popping" behavior when pressing back button after submitting rfq in `PaymentDetailsPage`