### PR TITLE
fix: open `PaymentLinkWebviewPage` if payin link found

### DIFF
--- a/lib/features/payment/payment_review_page.dart
+++ b/lib/features/payment/payment_review_page.dart
@@ -84,29 +84,33 @@ class PaymentReviewPage extends HookConsumerWidget {
                               ),
                             ),
                             NextButton(
-                              onPressed: () => paymentState.dap != null
-                                  ? Navigator.of(context).push(
-                                      MaterialPageRoute(
-                                        builder: (context) =>
-                                            PaymentLinkWebviewPage(
-                                          paymentLink: q.data.payin
-                                                  .paymentInstruction?.link ??
-                                              '',
-                                          onSubmit: () => _submitOrder(
-                                            context,
-                                            ref,
-                                            paymentState,
-                                            order,
+                              onPressed: () =>
+                                  q.data.payin.paymentInstruction?.link != null
+                                      ? Navigator.of(context).push(
+                                          MaterialPageRoute(
+                                            builder: (context) =>
+                                                PaymentLinkWebviewPage(
+                                              paymentLink: q
+                                                      .data
+                                                      .payin
+                                                      .paymentInstruction
+                                                      ?.link ??
+                                                  '',
+                                              onSubmit: () => _submitOrder(
+                                                context,
+                                                ref,
+                                                paymentState,
+                                                order,
+                                              ),
+                                            ),
                                           ),
+                                        )
+                                      : _submitOrder(
+                                          context,
+                                          ref,
+                                          paymentState,
+                                          order,
                                         ),
-                                      ),
-                                    )
-                                  : _submitOrder(
-                                      context,
-                                      ref,
-                                      paymentState,
-                                      order,
-                                    ),
                               title:
                                   '${Loc.of(context).pay} ${PaymentFeeDetails.calculateTotalAmount(q.data)} ${q.data.payin.currencyCode}',
                             ),

--- a/test/helpers/test_data.dart
+++ b/test/helpers/test_data.dart
@@ -85,19 +85,11 @@ class TestData {
             currencyCode: 'AUD',
             amount: '100',
             fee: '0.01',
-            paymentInstruction: PaymentInstruction(
-              link: 'https://block.xyz',
-              instruction: 'payin instruction',
-            ),
           ),
           payout: QuoteDetails(
             currencyCode: 'BTC',
             amount: '0.12',
             fee: '0.02',
-            paymentInstruction: PaymentInstruction(
-              link: 'https://block.xyz',
-              instruction: 'payout instruction',
-            ),
           ),
         ),
       );


### PR DESCRIPTION
- fix check in `PaymentReviewPage` to navigate to `PaymentLinkWebviewPage` if payin link is found in quote