### PR TITLE
chore: add check for `context.mounted`

### DIFF
--- a/lib/features/feature_flags/lucid/lucid_offerings_page.dart
+++ b/lib/features/feature_flags/lucid/lucid_offerings_page.dart
@@ -144,7 +144,9 @@ class LucidOfferingsPage extends HookConsumerWidget {
         state.value = AsyncData(offerings);
       }
     } on Exception catch (e) {
-      state.value = AsyncError(e, StackTrace.current);
+      if (context.mounted) {
+        state.value = AsyncError(e, StackTrace.current);
+      }
     }
   }
 }

--- a/lib/features/home/home_page.dart
+++ b/lib/features/home/home_page.dart
@@ -217,7 +217,9 @@ class HomePage extends HookConsumerWidget {
         state.value = AsyncData(exchanges);
       }
     } on Exception catch (e) {
-      state.value = AsyncError(e, StackTrace.current);
+      if (context.mounted) {
+        state.value = AsyncError(e, StackTrace.current);
+      }
     }
   }
 }

--- a/lib/features/kcc/kcc_retrieval_page.dart
+++ b/lib/features/kcc/kcc_retrieval_page.dart
@@ -100,7 +100,9 @@ class KccRetrievalPage extends HookConsumerWidget {
         state.value = AsyncData(addedCredential);
       }
     } on Exception catch (e) {
-      state.value = AsyncError(e, StackTrace.current);
+      if (context.mounted) {
+        state.value = AsyncError(e, StackTrace.current);
+      }
     }
   }
 }

--- a/lib/features/kcc/kcc_webview_page.dart
+++ b/lib/features/kcc/kcc_webview_page.dart
@@ -63,13 +63,13 @@ class KccWebviewPage extends HookConsumerWidget {
 
               controller.loadUrl(urlRequest: URLRequest(url: WebUri(fullPath)));
             },
-            onLoadStop: (controller, url) {
+            onLoadStop: (controller, url) async {
               if (url == null) {
                 return;
               }
 
               if (url.path.contains('finish.html')) {
-                Navigator.of(context).push(
+                await Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) => KccRetrievalPage(
                       pfi: pfi,
@@ -77,6 +77,7 @@ class KccWebviewPage extends HookConsumerWidget {
                     ),
                   ),
                 );
+                if (context.mounted) Navigator.pop(context);
               }
             },
             onCloseWindow: (controller) {
@@ -120,7 +121,9 @@ class KccWebviewPage extends HookConsumerWidget {
         state.value = AsyncData(idvRequest);
       }
     } on Exception catch (e) {
-      state.value = AsyncError(e, StackTrace.current);
+      if (context.mounted) {
+        state.value = AsyncError(e, StackTrace.current);
+      }
     }
   }
 }


### PR DESCRIPTION
- adds check for mounted context before updating `ValueNotifier` hooks that are called after async calls such as fetching tbdex resources or sending tbdex messages