### PR TITLE
fix: add check for null `payinAmount`

### DIFF
--- a/lib/features/payment/payment_amount_page.dart
+++ b/lib/features/payment/payment_amount_page.dart
@@ -126,7 +126,8 @@ class PaymentAmountPage extends HookConsumerWidget {
         ),
         const SizedBox(height: Grid.sm),
         NextButton(
-          onPressed: state.value?.payinAmount == '0'
+          onPressed: state.value?.payinAmount == null ||
+                  state.value?.payinAmount == '0'
               ? null
               : () => Navigator.of(context).push(
                     MaterialPageRoute(

--- a/lib/shared/number/number_display.dart
+++ b/lib/shared/number/number_display.dart
@@ -146,7 +146,8 @@ class NumberDisplay extends HookWidget {
   /// expected scale.
   String _denormalizeAmount(String formattedAmount) {
     final unformattedAmount = formattedAmount.replaceAll(',', '');
-    if (state.value?.payinAmount == unformattedAmount) {
+    if (state.value?.payinAmount == null ||
+        state.value?.payinAmount == unformattedAmount) {
       return formattedAmount;
     }
 


### PR DESCRIPTION
- adds check for null `payinAmount` to account for beginning state of `PayinAmountPage` input amount which fixes a glitch where the input amount would start at `0.` and then quickly switch to `0`