### PR TITLE
fix: prevent webview resizing

### DIFF
--- a/lib/features/kcc/kcc_webview_page.dart
+++ b/lib/features/kcc/kcc_webview_page.dart
@@ -44,6 +44,7 @@ class KccWebviewPage extends HookConsumerWidget {
     );
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(),
       body: idvRequest.value.when(
         loading: () => LoadingMessage(message: Loc.of(context).startingIdv),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -792,7 +792,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ae4c59d75da3eae9f320885d89d16536a89caf75
+      resolved-ref: ceaaf1c7bae703446c1b25bfcf059c098e1be864
       url: "https://github.com/TBD54566975/tbdex-dart.git"
     source: git
     version: "1.0.0"


### PR DESCRIPTION
- sets `resizeToAvoidBottomInset` to false to fix bug where screen goes blank when focusing on a new input field
