### PR TITLE
fix: check `context.mounted` before exiting `ModalFlow`

### DIFF
--- a/lib/features/kcc/kcc_consent_page.dart
+++ b/lib/features/kcc/kcc_consent_page.dart
@@ -21,7 +21,11 @@ class KccConsentPage extends HookConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+          onPressed: () {
+            if (context.mounted) {
+              Navigator.of(context, rootNavigator: true).pop();
+            }
+          },
           icon: const Icon(Icons.close),
         ),
       ),

--- a/lib/features/kcc/kcc_retrieval_page.dart
+++ b/lib/features/kcc/kcc_retrieval_page.dart
@@ -70,8 +70,12 @@ class KccRetrievalPage extends HookConsumerWidget {
                 ),
               ),
               NextButton(
-                onPressed: () => Navigator.of(context, rootNavigator: true)
-                    .pop(credential.value.asData?.value),
+                onPressed: () {
+                  if (context.mounted) {
+                    Navigator.of(context, rootNavigator: true)
+                        .pop(credential.value.asData?.value);
+                  }
+                },
               ),
             ],
           ),


### PR DESCRIPTION
- checks for mounted context before exiting the `ModalFlow` which is responsible for all KCC pages