### PR TITLE
feat: update order handling

### DIFF
--- a/lib/features/payment/payment_link_webview_page.dart
+++ b/lib/features/payment/payment_link_webview_page.dart
@@ -1,15 +1,17 @@
+import 'package:didpay/features/payment/payment_order_page.dart';
+import 'package:didpay/features/payment/payment_state.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class PaymentLinkWebviewPage extends HookConsumerWidget {
+  final PaymentState paymentState;
   final String paymentLink;
-  final Future<void> Function() onSubmit;
 
   const PaymentLinkWebviewPage({
+    required this.paymentState,
     required this.paymentLink,
-    required this.onSubmit,
     super.key,
   });
 
@@ -33,14 +35,21 @@ class PaymentLinkWebviewPage extends HookConsumerWidget {
 
           c.loadUrl(urlRequest: URLRequest(url: WebUri(fullPath)));
         },
-        onLoadStop: (controller, url) async {
+        onLoadStop: (controller, url) {
           if (url == null) {
             return;
           }
 
           if (url.path.contains('finish.html')) {
-            await onSubmit();
-            if (context.mounted) Navigator.of(context).pop();
+            if (context.mounted) {
+              Navigator.of(context).pushAndRemoveUntil(
+                MaterialPageRoute(
+                  builder: (context) =>
+                      PaymentOrderPage(paymentState: paymentState),
+                ),
+                (route) => false,
+              );
+            }
           }
         },
         onReceivedServerTrustAuthRequest: (controller, challenge) async {

--- a/lib/features/payment/payment_order_page.dart
+++ b/lib/features/payment/payment_order_page.dart
@@ -1,0 +1,82 @@
+import 'package:didpay/features/did/did_provider.dart';
+import 'package:didpay/features/payment/payment_state.dart';
+import 'package:didpay/features/tbdex/tbdex_service.dart';
+import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/confirmation_message.dart';
+import 'package:didpay/shared/error_message.dart';
+
+import 'package:didpay/shared/loading_message.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tbdex/tbdex.dart';
+
+class PaymentOrderPage extends HookConsumerWidget {
+  final PaymentState paymentState;
+
+  const PaymentOrderPage({
+    required this.paymentState,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final order = useState<AsyncValue<Order>>(const AsyncLoading());
+
+    useEffect(
+      () {
+        Future.microtask(
+          () async => _submitOrder(context, ref, paymentState, order),
+        );
+        return;
+      },
+      [],
+    );
+
+    return Scaffold(
+      appBar: AppBar(),
+      body: SafeArea(
+        child: order.value.when(
+          data: (_) => ConfirmationMessage(
+            message: Loc.of(context).orderConfirmed,
+          ),
+          loading: () => LoadingMessage(
+            message: Loc.of(context).confirmingYourOrder,
+          ),
+          error: (error, _) => ErrorMessage(
+            message: error.toString(),
+            onRetry: () => _submitOrder(
+              context,
+              ref,
+              paymentState,
+              order,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submitOrder(
+    BuildContext context,
+    WidgetRef ref,
+    PaymentState paymentState,
+    ValueNotifier<AsyncValue<Order>?> state,
+  ) async {
+    state.value = const AsyncLoading();
+
+    try {
+      final order = await ref.read(tbdexServiceProvider).submitOrder(
+            ref.read(didProvider),
+            paymentState.paymentAmountState?.pfiDid ?? '',
+            paymentState.paymentDetailsState?.exchangeId ?? '',
+          );
+
+      if (context.mounted) {
+        state.value = AsyncData(order);
+      }
+    } on Exception catch (e) {
+      state.value = AsyncError(e, StackTrace.current);
+    }
+  }
+}

--- a/lib/features/payment/payment_review_page.dart
+++ b/lib/features/payment/payment_review_page.dart
@@ -93,18 +93,13 @@ class PaymentReviewPage extends HookConsumerWidget {
                                           MaterialPageRoute(
                                             builder: (context) =>
                                                 PaymentLinkWebviewPage(
+                                              paymentState: paymentState,
                                               paymentLink: q
                                                       .data
                                                       .payin
                                                       .paymentInstruction
                                                       ?.link ??
                                                   '',
-                                              onSubmit: () => _submitOrder(
-                                                context,
-                                                ref,
-                                                paymentState,
-                                                order,
-                                              ),
                                             ),
                                           ),
                                         )


### PR DESCRIPTION
- adds `PaymentOrderPage` to handle submitting the order
- update `PaymentLinkWebviewPage` to push to the `PaymentOrderPage` to stop using navigation pop and its associated pop animation 