### PR TITLE
feat: add `PaymentQuoteWidget`

### DIFF
--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -4,10 +4,11 @@ import 'package:didpay/features/kcc/kcc_consent_page.dart';
 import 'package:didpay/features/payment/payment_details_state.dart';
 import 'package:didpay/features/payment/payment_method.dart';
 import 'package:didpay/features/payment/payment_methods_page.dart';
-import 'package:didpay/features/payment/payment_review_page.dart';
+import 'package:didpay/features/payment/payment_quote_widget.dart';
 import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/payment/payment_types_page.dart';
 import 'package:didpay/features/pfis/pfi.dart';
+import 'package:didpay/features/tbdex/tbdex_quote_notifier.dart';
 import 'package:didpay/features/tbdex/tbdex_service.dart';
 import 'package:didpay/features/transaction/transaction.dart';
 import 'package:didpay/features/vcs/vcs_notifier.dart';
@@ -33,6 +34,8 @@ class PaymentDetailsPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final quote = useState<AsyncValue<Quote?>>(ref.watch(quoteProvider));
+
     final rfq = useState<AsyncValue<Rfq>?>(null);
     final state = useState<PaymentDetailsState>(
       paymentState.paymentDetailsState ?? PaymentDetailsState(),
@@ -56,19 +59,32 @@ class PaymentDetailsPage extends HookConsumerWidget {
       [state.value.selectedPaymentType],
     );
 
-    final isSendingRfq = rfq.value?.isLoading ?? false;
+    final isAwaiting =
+        (rfq.value?.isLoading ?? false) || (quote.value.isLoading);
 
     return PopScope(
-      canPop: !isSendingRfq,
+      canPop: !isAwaiting,
       onPopInvoked: (_) {
-        if (isSendingRfq) rfq.value = null;
+        if (isAwaiting) {
+          rfq.value = null;
+          quote.value = const AsyncData(null);
+        }
       },
       child: Scaffold(
         appBar: AppBar(),
         body: SafeArea(
           child: rfq.value != null
               ? rfq.value!.when(
-                  data: (_) => Container(),
+                  data: (sentRfq) => PaymentQuoteWidget(
+                    paymentState: paymentState.copyWith(
+                      paymentDetailsState: state.value
+                          .copyWith(exchangeId: sentRfq.metadata.exchangeId),
+                    ),
+                    quote: quote,
+                    detailsPage:
+                        _buildPage(context, ref, availableMethods, state, rfq),
+                    ref: ref,
+                  ),
                   loading: () => LoadingMessage(
                     message: Loc.of(context).sendingYourRequest,
                   ),
@@ -82,40 +98,49 @@ class PaymentDetailsPage extends HookConsumerWidget {
                     ),
                   ),
                 )
-              : Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Header(
-                      title:
-                          paymentState.transactionType == TransactionType.send
-                              ? state.value.moneyAddresses != null
-                                  ? Loc.of(context).checkTheirPaymentDetails
-                                  : Loc.of(context).enterTheirPaymentDetails
-                              : Loc.of(context).enterYourPaymentDetails,
-                      subtitle: Loc.of(context).makeSureInfoIsCorrect,
-                    ),
-                    if (state.value.hasMultiplePaymentTypes)
-                      _buildPaymentTypeSelector(
-                        context,
-                        state,
-                      ),
-                    if (state.value.hasNoPaymentTypes ||
-                        state.value.selectedPaymentType != null)
-                      _buildPaymentMethodSelector(
-                        context,
-                        availableMethods,
-                        state,
-                      ),
-                    _buildPaymentForm(
-                      context,
-                      ref,
-                      state,
-                      rfq,
-                    ),
-                  ],
-                ),
+              : _buildPage(context, ref, availableMethods, state, rfq),
         ),
       ),
+    );
+  }
+
+  Widget _buildPage(
+    BuildContext context,
+    WidgetRef ref,
+    List<PaymentMethod>? availableMethods,
+    ValueNotifier<PaymentDetailsState> state,
+    ValueNotifier<AsyncValue<Rfq>?> rfq,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Header(
+          title: paymentState.transactionType == TransactionType.send
+              ? state.value.moneyAddresses != null
+                  ? Loc.of(context).checkTheirPaymentDetails
+                  : Loc.of(context).enterTheirPaymentDetails
+              : Loc.of(context).enterYourPaymentDetails,
+          subtitle: Loc.of(context).makeSureInfoIsCorrect,
+        ),
+        if (state.value.hasMultiplePaymentTypes)
+          _buildPaymentTypeSelector(
+            context,
+            state,
+          ),
+        if (state.value.hasNoPaymentTypes ||
+            state.value.selectedPaymentType != null)
+          _buildPaymentMethodSelector(
+            context,
+            availableMethods,
+            state,
+          ),
+        _buildPaymentForm(
+          context,
+          ref,
+          state,
+          rfq,
+        ),
+      ],
     );
   }
 
@@ -266,18 +291,7 @@ class PaymentDetailsPage extends HookConsumerWidget {
           );
 
       if (context.mounted && rfq.value != null) {
-        await Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => PaymentReviewPage(
-              paymentState: updatedPaymentState.copyWith(
-                paymentDetailsState: updatedPaymentState.paymentDetailsState
-                    ?.copyWith(exchangeId: sentRfq.metadata.exchangeId),
-              ),
-            ),
-          ),
-        );
-
-        if (context.mounted) rfq.value = null;
+        rfq.value = AsyncData(sentRfq);
       }
     } on Exception catch (e) {
       rfq.value = AsyncError(e, StackTrace.current);

--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -81,8 +81,7 @@ class PaymentDetailsPage extends HookConsumerWidget {
                           .copyWith(exchangeId: sentRfq.metadata.exchangeId),
                     ),
                     quote: quote,
-                    detailsPage:
-                        _buildPage(context, ref, availableMethods, state, rfq),
+                    rfq: rfq,
                     ref: ref,
                   ),
                   loading: () => LoadingMessage(

--- a/lib/features/payment/payment_order_page.dart
+++ b/lib/features/payment/payment_order_page.dart
@@ -4,7 +4,6 @@ import 'package:didpay/features/tbdex/tbdex_service.dart';
 import 'package:didpay/l10n/app_localizations.dart';
 import 'package:didpay/shared/confirmation_message.dart';
 import 'package:didpay/shared/error_message.dart';
-
 import 'package:didpay/shared/loading_message.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';

--- a/lib/features/payment/payment_quote_widget.dart
+++ b/lib/features/payment/payment_quote_widget.dart
@@ -1,0 +1,91 @@
+import 'package:didpay/features/payment/payment_review_page.dart';
+import 'package:didpay/features/payment/payment_state.dart';
+import 'package:didpay/features/tbdex/tbdex_quote_notifier.dart';
+import 'package:didpay/l10n/app_localizations.dart';
+import 'package:didpay/shared/error_message.dart';
+import 'package:didpay/shared/loading_message.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:tbdex/tbdex.dart';
+
+class PaymentQuoteWidget extends HookWidget {
+  final PaymentState paymentState;
+  final ValueNotifier<AsyncValue<Quote?>> quote;
+  final Widget detailsPage;
+  final WidgetRef ref;
+
+  const PaymentQuoteWidget({
+    required this.paymentState,
+    required this.quote,
+    required this.detailsPage,
+    required this.ref,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    TbdexQuoteNotifier getQuoteNotifier() => ref.read(quoteProvider.notifier);
+
+    useEffect(
+      () {
+        Future.microtask(() async {
+          if (context.mounted) {
+            await _pollForQuote(context, ref, getQuoteNotifier(), quote);
+          }
+        });
+        return getQuoteNotifier().stopPolling;
+      },
+      [],
+    );
+
+    return quote.value.when(
+      data: (q) => q == null ? Container() : detailsPage,
+      loading: () => LoadingMessage(
+        message: Loc.of(context).gettingYourQuote,
+      ),
+      error: (error, _) => ErrorMessage(
+        message: error.toString(),
+        onRetry: () => _pollForQuote(context, ref, getQuoteNotifier(), quote),
+      ),
+    );
+  }
+
+  Future<void> _pollForQuote(
+    BuildContext context,
+    WidgetRef ref,
+    TbdexQuoteNotifier quoteNotifier,
+    ValueNotifier<AsyncValue<Quote?>> state,
+  ) async {
+    state.value = const AsyncLoading();
+
+    try {
+      final quote = await quoteNotifier.startPolling(
+        paymentState.paymentAmountState?.pfiDid ?? '',
+        paymentState.paymentDetailsState?.exchangeId ?? '',
+      );
+
+      if (context.mounted && quote != null) {
+        quoteNotifier.stopPolling();
+
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => PaymentReviewPage(
+              paymentState: paymentState.copyWith(
+                quote: quote,
+              ),
+            ),
+          ),
+        );
+
+        if (context.mounted) {
+          state.value = AsyncData(quote);
+        }
+      }
+    } on Exception catch (e) {
+      if (context.mounted) {
+        state.value = AsyncError(e, StackTrace.current);
+      }
+    }
+  }
+}

--- a/lib/features/payment/payment_state.dart
+++ b/lib/features/payment/payment_state.dart
@@ -1,16 +1,19 @@
 import 'package:didpay/features/payment/payment_amount_state.dart';
 import 'package:didpay/features/payment/payment_details_state.dart';
 import 'package:didpay/features/transaction/transaction.dart';
+import 'package:tbdex/tbdex.dart';
 
 class PaymentState {
   final TransactionType transactionType;
   final PaymentAmountState? paymentAmountState;
   final PaymentDetailsState? paymentDetailsState;
+  final Quote? quote;
 
   const PaymentState({
     required this.transactionType,
     this.paymentAmountState,
     this.paymentDetailsState,
+    this.quote,
   });
 
   String? get filterPayinCurrency {
@@ -91,11 +94,13 @@ class PaymentState {
   PaymentState copyWith({
     PaymentAmountState? paymentAmountState,
     PaymentDetailsState? paymentDetailsState,
+    Quote? quote,
   }) {
     return PaymentState(
       transactionType: transactionType,
       paymentAmountState: paymentAmountState ?? this.paymentAmountState,
       paymentDetailsState: paymentDetailsState ?? this.paymentDetailsState,
+      quote: quote ?? this.quote,
     );
   }
 }

--- a/lib/features/transaction/transaction_tile.dart
+++ b/lib/features/transaction/transaction_tile.dart
@@ -76,7 +76,7 @@ class TransactionTile extends HookConsumerWidget {
                     ),
                     margin: const EdgeInsets.symmetric(horizontal: Grid.xl),
                     behavior: SnackBarBehavior.floating,
-                    duration: const Duration(seconds: 10),
+                    duration: const Duration(seconds: 1),
                     backgroundColor: Theme.of(context).colorScheme.surface,
                   ),
                 );

--- a/test/features/payment/payment_review_page_test.dart
+++ b/test/features/payment/payment_review_page_test.dart
@@ -62,6 +62,7 @@ void main() async {
                   offering.data.payin.methods.first,
                 ),
               ),
+              quote: quote,
             ),
           ),
           overrides: [
@@ -106,19 +107,6 @@ void main() async {
       await tester.pumpAndSettle();
 
       expect(find.text('DEBIT_CARD'), findsOneWidget);
-    });
-
-    testWidgets('should show order confirmation on tap of submit button',
-        (tester) async {
-      await tester.pumpWidget(
-        WidgetHelpers.testableWidget(child: reviewPaymentPageTestWidget()),
-      );
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('Pay 100.01 AUD'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Order confirmed!'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
follow up pr to https://github.com/TBD54566975/didpay/pull/241
- adds `PaymentQuoteWidget` to handle polling for quote in `PaymentDetailsPage` to allow the `sending request` spinner to switch to `getting quote` without pushing to a new page