### PR TITLE
fix: have retry for failed kcc restart idv widget

### DIFF
--- a/lib/features/kcc/kcc_retrieval_page.dart
+++ b/lib/features/kcc/kcc_retrieval_page.dart
@@ -45,7 +45,7 @@ class KccRetrievalPage extends HookConsumerWidget {
               LoadingMessage(message: Loc.of(context).verifyingYourIdentity),
           error: (error, stackTrace) => ErrorMessage(
             message: error.toString(),
-            onRetry: () => _pollForCredential(context, ref, credential),
+            onRetry: () => Navigator.of(context).pop(),
           ),
           data: (data) => Column(
             mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
- this pr reroutes the `Tap to retry` button that appears when unable to retrieve a KCC in `KccRetrievalPage`
  - restarts `KccWebviewPage` instead of re-polling for a KCC