### PR TITLE
fix: update tbdex dep

### DIFF
--- a/lib/features/account/account_balance_card.dart
+++ b/lib/features/account/account_balance_card.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:didpay/features/account/account_balance_notifier.dart';
+import 'package:didpay/features/did/did_provider.dart';
 // import 'package:didpay/features/payment/payment_amount_page.dart';
 // import 'package:didpay/features/payment/payment_state.dart';
 import 'package:didpay/features/pfis/pfis_notifier.dart';
@@ -16,12 +17,10 @@ class AccountBalanceCard extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pfis = ref.watch(pfisProvider);
-    // final accountBalance = ref.watch(accountBalanceProvider);
+    final accountBalance = ref.watch(accountBalanceProvider);
 
-    // final accountTotal = accountBalance.asData?.value?.total ?? '0';
-    // final accountCurrency = accountBalance.asData?.value?.currencyCode ?? '';
-    const accountTotal = '0';
-    const accountCurrency = 'USD';
+    final accountTotal = accountBalance.asData?.value?.total ?? '0';
+    final accountCurrency = accountBalance.asData?.value?.currencyCode ?? 'USD';
 
     AccountBalanceNotifier getAccountBalanceNotifier() =>
         ref.read(accountBalanceProvider.notifier);
@@ -29,7 +28,8 @@ class AccountBalanceCard extends HookConsumerWidget {
     useEffect(
       () {
         Future.microtask(
-          () async => getAccountBalanceNotifier().startPolling(pfis),
+          () async => getAccountBalanceNotifier()
+              .startPolling(ref.read(didProvider), pfis),
         );
         return getAccountBalanceNotifier().stopPolling;
       },

--- a/lib/features/account/account_balance_notifier.dart
+++ b/lib/features/account/account_balance_notifier.dart
@@ -4,6 +4,7 @@ import 'package:didpay/features/account/account_balance.dart';
 import 'package:didpay/features/pfis/pfi.dart';
 import 'package:didpay/features/tbdex/tbdex_service.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:web5/web5.dart';
 
 final accountBalanceProvider =
     AsyncNotifierProvider.autoDispose<AccountBalanceNotifier, AccountBalance?>(
@@ -16,12 +17,15 @@ class AccountBalanceNotifier extends AutoDisposeAsyncNotifier<AccountBalance?> {
   @override
   FutureOr<AccountBalance?> build() async => null;
 
-  Future<AccountBalance?> fetchAccountBalance(List<Pfi>? pfis) async {
+  Future<AccountBalance?> fetchAccountBalance(
+    BearerDid did,
+    List<Pfi>? pfis,
+  ) async {
     if (pfis == null || pfis.isEmpty) return null;
 
     try {
       final tbdexService = ref.read(tbdexServiceProvider);
-      final accountBalance = await tbdexService.getAccountBalance(pfis);
+      final accountBalance = await tbdexService.getAccountBalance(did, pfis);
 
       state = AsyncValue.data(accountBalance);
       return accountBalance;
@@ -31,13 +35,13 @@ class AccountBalanceNotifier extends AutoDisposeAsyncNotifier<AccountBalance?> {
     return null;
   }
 
-  void startPolling(List<Pfi> pfis) {
+  void startPolling(BearerDid did, List<Pfi> pfis) {
     _timer?.cancel();
-    fetchAccountBalance(pfis);
+    fetchAccountBalance(did, pfis);
 
     _timer = Timer.periodic(
       const Duration(minutes: 3),
-      (timer) => fetchAccountBalance(pfis),
+      (timer) => fetchAccountBalance(did, pfis),
     );
   }
 

--- a/lib/features/tbdex/tbdex_service.dart
+++ b/lib/features/tbdex/tbdex_service.dart
@@ -44,14 +44,17 @@ class TbdexService {
     return offeringsMap;
   }
 
-  Future<AccountBalance> getAccountBalance(List<Pfi> pfis) async {
+  Future<AccountBalance> getAccountBalance(
+    BearerDid did,
+    List<Pfi> pfis,
+  ) async {
     final balancesMap = <Pfi, List<Balance>>{};
     var totalAvailable = Decimal.zero;
     String? currencyCode;
 
     for (final pfi in pfis) {
       try {
-        final balances = await TbdexHttpClient.listBalances(pfi.did);
+        final balances = await TbdexHttpClient.listBalances(did, pfi.did);
         balancesMap[pfi] = balances;
 
         for (final balance in balances) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -792,7 +792,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: ceaaf1c7bae703446c1b25bfcf059c098e1be864
+      resolved-ref: "6778d10d1b8bda104278207ce67a59357b78dfb4"
       url: "https://github.com/TBD54566975/tbdex-dart.git"
     source: git
     version: "1.0.0"

--- a/test/features/app/app_tabs_test.dart
+++ b/test/features/app/app_tabs_test.dart
@@ -39,7 +39,7 @@ void main() async {
     ).thenAnswer((_) async => {});
 
     when(
-      () => mockTbdexService.getAccountBalance(pfis),
+      () => mockTbdexService.getAccountBalance(did, pfis),
     ).thenAnswer(
       (_) async => accountBalance,
     );

--- a/test/features/app/app_test.dart
+++ b/test/features/app/app_test.dart
@@ -34,7 +34,7 @@ void main() async {
     ).thenAnswer((_) async => {});
 
     when(
-      () => mockTbdexService.getAccountBalance(pfis),
+      () => mockTbdexService.getAccountBalance(did, pfis),
     ).thenAnswer(
       (_) async => TestData.getAccountBalance(),
     );

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -56,7 +56,7 @@ void main() async {
       ).thenAnswer((_) async => {});
 
       when(
-        () => mockTbdexService.getAccountBalance(pfis),
+        () => mockTbdexService.getAccountBalance(did, pfis),
       ).thenAnswer(
         (_) async => accountBalance,
       );

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -81,7 +81,7 @@ void main() async {
       await tester.pumpWidget(homePageTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.widgetWithText(AccountBalanceCard, '0'), findsOneWidget);
+      expect(find.widgetWithText(AccountBalanceCard, '101'), findsOneWidget);
       expect(find.widgetWithText(AccountBalanceCard, 'USD'), findsOneWidget);
     });
 


### PR DESCRIPTION
- updates tbdex to include `OrderStatus` enums which were breaking `OrderStatus.fromJson`
- passes in `BearerDid` to account balance calls to allow for protected endpoint use: https://github.com/TBD54566975/tbdex/blob/main/specs/http-api/README.md#protected-endpoints