### PR TITLE
fix: remove `PopScope` from `ModalFlow`

### DIFF
--- a/lib/shared/modal/modal_flow.dart
+++ b/lib/shared/modal/modal_flow.dart
@@ -6,13 +6,11 @@ class ModalFlow extends StatelessWidget {
   const ModalFlow({required this.initialWidget, super.key});
 
   @override
-  Widget build(BuildContext context) => PopScope(
-        child: Navigator(
-          onGenerateRoute: (settings) {
-            return MaterialPageRoute(
-              builder: (context) => initialWidget,
-            );
-          },
-        ),
+  Widget build(BuildContext context) => Navigator(
+        onGenerateRoute: (settings) {
+          return MaterialPageRoute(
+            builder: (context) => initialWidget,
+          );
+        },
       );
 }


### PR DESCRIPTION
attempts fix for black screen that occurs when popping from `KccRetrievalPage` back to `PaymentDetailsPage`