### PR TITLE
feat: add `ConfirmDialog` in `PaymentReviewPage`

### DIFF
--- a/lib/features/tbdex/tbdex_service.dart
+++ b/lib/features/tbdex/tbdex_service.dart
@@ -178,7 +178,7 @@ class TbdexService {
     return rfq;
   }
 
-  Future<Order> submitOrder(
+  Future<Order> sendOrder(
     BearerDid did,
     String pfiDid,
     String exchangeId,
@@ -197,22 +197,22 @@ class TbdexService {
     return order;
   }
 
-  Future<Close> submitClose(
+  Future<Cancel> sendCancel(
     BearerDid did,
     String pfiDid,
     String exchangeId,
   ) async {
-    final closeData = CloseData(reason: 'User requested');
-    final close = Close.create(pfiDid, did.uri, exchangeId, closeData);
-    await close.sign(did);
+    final cancelData = CancelData(reason: 'User requested');
+    final cancel = Cancel.create(pfiDid, did.uri, exchangeId, cancelData);
+    await cancel.sign(did);
 
     try {
-      await TbdexHttpClient.submitClose(close);
+      await TbdexHttpClient.submitCancel(cancel);
     } on Exception {
       rethrow;
     }
 
-    return close;
+    return cancel;
   }
 
   Future<Quote> pollForQuote(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -165,6 +165,7 @@
         }
     },
     "ifYouExitNow": "If you exit now, you'll lose all your progress",
+    "ifYouGoBackNow": "If you go back now, you'll lose your quote",
     "enterADap": "Enter a Decentralized Agnostic Paytag (DAP)",
     "verifyingDap": "Verifying DAP...",
     "placeholderDap": "@username/didpay.me",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -853,6 +853,12 @@ abstract class Loc {
   /// **'If you exit now, you\'ll lose all your progress'**
   String get ifYouExitNow;
 
+  /// No description provided for @ifYouGoBackNow.
+  ///
+  /// In en, this message translates to:
+  /// **'If you go back now, you\'ll lose your quote'**
+  String get ifYouGoBackNow;
+
   /// No description provided for @enterADap.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -396,6 +396,9 @@ class LocEn extends Loc {
   String get ifYouExitNow => 'If you exit now, you\'ll lose all your progress';
 
   @override
+  String get ifYouGoBackNow => 'If you go back now, you\'ll lose your quote';
+
+  @override
   String get enterADap => 'Enter a Decentralized Agnostic Paytag (DAP)';
 
   @override

--- a/lib/shared/json_schema_form.dart
+++ b/lib/shared/json_schema_form.dart
@@ -53,9 +53,8 @@ class JsonSchemaForm extends HookWidget {
 
             if (!formState.value.containsKey(key)) {
               final formatter = TextInputUtil.getMaskFormatter(pattern);
-              final controller = TextEditingController(
-                text: formState.value[key]?.formData ?? '',
-              );
+              final initialText = state.formData?[key] ?? '';
+              final controller = TextEditingController(text: initialText);
 
               controller.addListener(
                 () => formState.value = {
@@ -69,7 +68,7 @@ class JsonSchemaForm extends HookWidget {
               );
 
               formState.value[key] = _FormFieldStateData(
-                formData: '',
+                formData: initialText,
                 controller: controller,
                 formatter: formatter,
               );

--- a/test/features/payment/payment_review_page_test.dart
+++ b/test/features/payment/payment_review_page_test.dart
@@ -34,7 +34,7 @@ void main() async {
     mockTbdexQuoteNotifier = MockTbdexQuoteNotifier();
 
     when(
-      () => mockTbdexService.submitOrder(any(), any(), any()),
+      () => mockTbdexService.sendOrder(any(), any(), any()),
     ).thenAnswer((_) async => order);
 
     when(


### PR DESCRIPTION
this pr adds a confirmation dialog in `PaymentReviewPage` to alert the user that going back from that page means that quotes will have to be re-fetched 

![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-06 at 15 38 59](https://github.com/user-attachments/assets/b023ccc7-bd9d-4ec5-ab42-2ba6642e1d07)
