### PR TITLE
chore: improve `TbdexService`

### DIFF
--- a/lib/features/tbdex/tbdex_service.dart
+++ b/lib/features/tbdex/tbdex_service.dart
@@ -39,7 +39,7 @@ class TbdexService {
       );
     }
 
-    await Future.delayed(const Duration(milliseconds: 500));
+    await Future.delayed(const Duration(milliseconds: 300));
 
     return offeringsMap;
   }
@@ -167,13 +167,14 @@ class TbdexService {
     );
 
     await rfq.sign(did);
-    await Future.delayed(const Duration(milliseconds: 500));
 
     try {
       await TbdexHttpClient.createExchange(rfq);
     } on Exception {
       rethrow;
     }
+
+    await Future.delayed(const Duration(milliseconds: 300));
 
     return rfq;
   }
@@ -183,16 +184,16 @@ class TbdexService {
     String pfiDid,
     String exchangeId,
   ) async {
-    await Future.delayed(const Duration(seconds: 1));
     final order = Order.create(pfiDid, did.uri, exchangeId);
     await order.sign(did);
-    await Future.delayed(const Duration(milliseconds: 500));
 
     try {
       await TbdexHttpClient.submitOrder(order);
     } on Exception {
       rethrow;
     }
+
+    await Future.delayed(const Duration(milliseconds: 300));
 
     return order;
   }

--- a/lib/features/tbdex/tbdex_service.dart
+++ b/lib/features/tbdex/tbdex_service.dart
@@ -86,8 +86,9 @@ class TbdexService {
 
         final validExchanges = await Future.wait(
           exchanges.map((exchangeId) async {
-            final isValid = await _isValidExchange(did, pfi.did, exchangeId);
-            return isValid ? exchangeId : null;
+            final isComplete =
+                await _isCompleteExchange(did, pfi.did, exchangeId);
+            return isComplete ? exchangeId : null;
           }),
         );
 
@@ -103,7 +104,7 @@ class TbdexService {
     return exchangesMap;
   }
 
-  Future<bool> _isValidExchange(
+  Future<bool> _isCompleteExchange(
     BearerDid did,
     String pfiDid,
     String exchangeId,
@@ -116,7 +117,7 @@ class TbdexService {
       );
 
       return exchange
-          .any((message) => message.metadata.kind == MessageKind.order);
+          .any((message) => message.metadata.kind == MessageKind.orderstatus);
     } on Exception {
       return false;
     }


### PR DESCRIPTION
- reduces added delay in `getOfferings()`, `sendRfq()`, and `sendOrder()` from 500 ms to 300 ms
- only return exchanges that contain a `OrderStatus` message in the exchange