### PR TITLE
chore: refactor `onSubmit()` callback in `JsonSchemaForm`

### DIFF
--- a/lib/shared/json_schema_form.dart
+++ b/lib/shared/json_schema_form.dart
@@ -10,7 +10,7 @@ import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
 class JsonSchemaForm extends HookWidget {
   final PaymentDetailsState state;
-  final void Function(Map<String, String>) onSubmit;
+  final Future<void> Function(Map<String, String>) onSubmit;
 
   final _formKey = GlobalKey<FormState>();
 

--- a/test/shared/json_schema_form_test.dart
+++ b/test/shared/json_schema_form_test.dart
@@ -29,7 +29,7 @@ void main() {
 
   group('JsonSchemaForm', () {
     Widget jsonSchemaFormTestWidget({
-      void Function(Map<String, String>)? onSubmit,
+      Future<void> Function(Map<String, String>)? onSubmit,
     }) =>
         WidgetHelpers.testableWidget(
           child: JsonSchemaForm(
@@ -37,7 +37,7 @@ void main() {
               selectedPaymentMethod:
                   PaymentMethod(kind: '', schema: jsonSchemaString),
             ),
-            onSubmit: onSubmit ?? (_) {},
+            onSubmit: onSubmit ?? (_) async {},
           ),
         );
     testWidgets('should render form fields based on JSON schema',
@@ -70,7 +70,7 @@ void main() {
 
       await tester.pumpWidget(
         jsonSchemaFormTestWidget(
-          onSubmit: (formData) => submittedData = formData,
+          onSubmit: (formData) async => submittedData = formData,
         ),
       );
 


### PR DESCRIPTION
this pr simplifies the `onSubmit()` callback in the `JsonSchemaForm` widget by making it async and cleaning up the credentials/rfq logic