### PR TITLE
fix: reset `TextEditingController` to prevent use after disposal

### DIFF
--- a/lib/shared/json_schema_form.dart
+++ b/lib/shared/json_schema_form.dart
@@ -46,6 +46,8 @@ class JsonSchemaForm extends HookWidget {
 
     useEffect(
       () {
+        formState.value = {};
+
         if (properties != null) {
           properties.forEach((key, value) {
             final valueMap = value as Map<String, dynamic>;


### PR DESCRIPTION
this pr fixes a UI bug where you could not reenter `PaymentDetailsPage` after re-selecting a payment method or payment type in `PaymentMethodsPage` or `PaymentTypesPage`