### PR TITLE
feat: use `PresentationDefinition` id to initiate KCC application

### DIFF
--- a/lib/features/kcc/kcc_consent_page.dart
+++ b/lib/features/kcc/kcc_consent_page.dart
@@ -8,11 +8,17 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:web5/web5.dart';
 
 class KccConsentPage extends HookConsumerWidget {
   final Pfi pfi;
+  final PresentationDefinition presentationDefinition;
 
-  const KccConsentPage({required this.pfi, super.key});
+  const KccConsentPage({
+    required this.pfi,
+    required this.presentationDefinition,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -44,7 +50,10 @@ class KccConsentPage extends HookConsumerWidget {
                   ? null
                   : () => Navigator.of(context).push(
                         MaterialPageRoute(
-                          builder: (_) => KccWebviewPage(pfi: pfi),
+                          builder: (_) => KccWebviewPage(
+                            pfi: pfi,
+                            presentationDefinition: presentationDefinition,
+                          ),
                         ),
                       ),
             ),

--- a/lib/features/kcc/kcc_webview_page.dart
+++ b/lib/features/kcc/kcc_webview_page.dart
@@ -13,12 +13,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:web5/web5.dart';
 
 class KccWebviewPage extends HookConsumerWidget {
   final Pfi pfi;
+  final PresentationDefinition presentationDefinition;
 
   const KccWebviewPage({
     required this.pfi,
+    required this.presentationDefinition,
     super.key,
   });
 
@@ -77,9 +80,9 @@ class KccWebviewPage extends HookConsumerWidget {
                   ),
                 ),
               );
+            } else {
+              controller.loadUrl(urlRequest: URLRequest(url: WebUri(fullPath)));
             }
-
-            controller.loadUrl(urlRequest: URLRequest(url: WebUri(fullPath)));
           },
           onLoadStop: (controller, url) async {
             if (url == null) {
@@ -131,7 +134,7 @@ class KccWebviewPage extends HookConsumerWidget {
     try {
       final idvRequest = await ref
           .read(kccIssuanceProvider)
-          .getIdvRequest(pfi, ref.read(didProvider));
+          .getIdvRequest(pfi, presentationDefinition, ref.read(didProvider));
 
       if (context.mounted) {
         state.value = AsyncData(idvRequest);

--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -158,10 +158,23 @@ class PaymentDetailsPage extends HookConsumerWidget {
                       );
 
               if (credentials == null) {
-                final issuedCredential = await _startKccFlow(context);
+                final issuedCredential = await Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => ModalFlow(
+                      initialWidget: KccConsentPage(
+                        pfi: Pfi(
+                          did: paymentState.paymentAmountState?.pfiDid ?? '',
+                        ),
+                        presentationDefinition: presentationDefinition,
+                      ),
+                    ),
+                    fullscreenDialog: true,
+                  ),
+                );
+
                 if (issuedCredential == null) return;
 
-                credentials = issuedCredential;
+                credentials = [issuedCredential as String];
               }
 
               state.value = state.value.copyWith(credentialsJwt: credentials);
@@ -260,23 +273,6 @@ class PaymentDetailsPage extends HookConsumerWidget {
         ),
       ],
     );
-  }
-
-  Future<List<String>?> _startKccFlow(BuildContext context) async {
-    final credential = await Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => ModalFlow(
-          initialWidget: KccConsentPage(
-            pfi: Pfi(
-              did: paymentState.paymentAmountState?.pfiDid ?? '',
-            ),
-          ),
-        ),
-        fullscreenDialog: true,
-      ),
-    );
-
-    return credential == null ? null : [credential as String];
   }
 
   Future<void> _sendRfq(


### PR DESCRIPTION
this pr ensures that the `PresentationDefinition` id (found in the offering selected by the user) is used to initiate the KCC application via a query parameter `presentation_definition_id` as detailed in the [spec](https://github.com/TBD54566975/known-customer-credential?tab=readme-ov-file#request)