### PR TITLE
feat: add `DapState`

### DIFF
--- a/lib/features/dap/dap_state.dart
+++ b/lib/features/dap/dap_state.dart
@@ -1,0 +1,56 @@
+import 'package:dap/dap.dart';
+import 'package:didpay/features/payment/payment_method.dart';
+
+class DapState {
+  final MoneyAddress? selectedAddress;
+  final List<MoneyAddress>? moneyAddresses;
+
+  DapState({
+    this.selectedAddress,
+    this.moneyAddresses,
+  });
+
+  static const Map<String, String> protocolToKindMap = {
+    'addr': 'BTC_ONCHAIN_PAYOUT',
+    'lnaddr': 'BTC_LN_PAYOUT',
+    'sol': 'USDC_ONCHAIN',
+  };
+
+  String? get protocol => selectedAddress?.css.split(':').firstOrNull;
+
+  String? get paymentAddress => selectedAddress?.css.split(':').lastOrNull;
+
+  List<String>? get currencies =>
+      moneyAddresses?.map((address) => address.currency).toList();
+
+  MoneyAddress? getSelectedMoneyAddress(String? paymentCurrency) =>
+      moneyAddresses?.firstWhere(
+        (address) => address.currency.toUpperCase() == paymentCurrency,
+      );
+
+  List<PaymentMethod>? filterPaymentMethods(
+    List<PaymentMethod>? paymentMethods,
+  ) {
+    final protocolKinds = moneyAddresses
+        ?.map(
+          (address) =>
+              protocolToKindMap[address.css.split(':').firstOrNull ?? ''],
+        )
+        .toSet();
+
+    return paymentMethods
+        ?.where(
+          (method) => protocolKinds?.contains(method.kind) ?? false,
+        )
+        .toList();
+  }
+
+  DapState copyWith({
+    MoneyAddress? selectedAddress,
+    List<MoneyAddress>? moneyAddresses,
+  }) =>
+      DapState(
+        selectedAddress: selectedAddress ?? this.selectedAddress,
+        moneyAddresses: moneyAddresses ?? this.moneyAddresses,
+      );
+}

--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:didpay/features/dap/dap_state.dart';
 import 'package:didpay/features/did/did_provider.dart';
 import 'package:didpay/features/kcc/kcc_consent_page.dart';
 import 'package:didpay/features/payment/payment_details_state.dart';
@@ -27,9 +28,11 @@ import 'package:tbdex/tbdex.dart';
 
 class PaymentDetailsPage extends HookConsumerWidget {
   final PaymentState paymentState;
+  final DapState? dapState;
 
   const PaymentDetailsPage({
     required this.paymentState,
+    this.dapState,
     super.key,
   });
 
@@ -104,7 +107,7 @@ class PaymentDetailsPage extends HookConsumerWidget {
                     Header(
                       title:
                           paymentState.transactionType == TransactionType.send
-                              ? state.value.moneyAddresses != null
+                              ? dapState?.moneyAddresses != null
                                   ? Loc.of(context).checkTheirPaymentDetails
                                   : Loc.of(context).enterTheirPaymentDetails
                               : Loc.of(context).enterYourPaymentDetails,
@@ -144,6 +147,7 @@ class PaymentDetailsPage extends HookConsumerWidget {
       Expanded(
         child: JsonSchemaForm(
           state: state.value,
+          dapState: dapState,
           onSubmit: (formData) async {
             state.value = state.value.copyWith(formData: formData);
 

--- a/lib/features/payment/payment_details_state.dart
+++ b/lib/features/payment/payment_details_state.dart
@@ -1,4 +1,3 @@
-import 'package:dap/dap.dart';
 import 'package:didpay/features/payment/payment_method.dart';
 
 class PaymentDetailsState {
@@ -8,7 +7,6 @@ class PaymentDetailsState {
   final String? selectedPaymentType;
   final PaymentMethod? selectedPaymentMethod;
   final List<PaymentMethod>? paymentMethods;
-  final List<MoneyAddress>? moneyAddresses;
   final List<String>? credentialsJwt;
   final Map<String, String>? formData;
 
@@ -19,7 +17,6 @@ class PaymentDetailsState {
     this.selectedPaymentType,
     this.selectedPaymentMethod,
     this.paymentMethods,
-    this.moneyAddresses,
     this.credentialsJwt,
     this.formData,
   });
@@ -37,17 +34,6 @@ class PaymentDetailsState {
           )
           .toList();
 
-  List<PaymentMethod>? filterDapProtocol() => paymentMethods
-      ?.where(
-        (method) => method.kind.contains(
-          PaymentMethod.protocolPaymentMap[
-                  moneyAddresses?.firstOrNull?.css.split(':').firstOrNull ??
-                      ''] ??
-              '',
-        ),
-      )
-      .toList();
-
   PaymentDetailsState copyWith({
     String? paymentCurrency,
     String? paymentName,
@@ -55,7 +41,6 @@ class PaymentDetailsState {
     String? selectedPaymentType,
     PaymentMethod? selectedPaymentMethod,
     List<PaymentMethod>? paymentMethods,
-    List<MoneyAddress>? moneyAddresses,
     List<String>? credentialsJwt,
     Map<String, String>? formData,
   }) {
@@ -67,7 +52,6 @@ class PaymentDetailsState {
       selectedPaymentMethod:
           selectedPaymentMethod ?? this.selectedPaymentMethod,
       paymentMethods: paymentMethods ?? this.paymentMethods,
-      moneyAddresses: moneyAddresses ?? this.moneyAddresses,
       credentialsJwt: credentialsJwt ?? this.credentialsJwt,
       formData: formData ?? this.formData,
     );

--- a/lib/features/payment/payment_method.dart
+++ b/lib/features/payment/payment_method.dart
@@ -48,9 +48,4 @@ class PaymentMethod {
       fee: fee ?? this.fee,
     );
   }
-
-  static const Map<String, String> protocolPaymentMap = {
-    'addr': 'BTC_ONCHAIN_PAYOUT',
-    'lnaddr': 'BTC_LN_PAYOUT',
-  };
 }

--- a/lib/features/payment/payment_state.dart
+++ b/lib/features/payment/payment_state.dart
@@ -30,10 +30,8 @@ class PaymentState {
     switch (transactionType) {
       case TransactionType.deposit:
         return 'USDC';
+      // TODO(ethan-tbd): use dap currencies here when tbdex-dart supports list of currencies
       case TransactionType.send:
-        return paymentDetailsState?.paymentCurrency ??
-            paymentDetailsState?.moneyAddresses?.firstOrNull?.currency
-                .toUpperCase();
       case TransactionType.withdraw:
         return null;
     }

--- a/lib/features/send/send_page.dart
+++ b/lib/features/send/send_page.dart
@@ -1,5 +1,6 @@
 import 'package:dap/dap.dart';
 import 'package:didpay/features/dap/dap_form.dart';
+import 'package:didpay/features/dap/dap_state.dart';
 import 'package:didpay/features/feature_flags/feature_flag.dart';
 import 'package:didpay/features/feature_flags/feature_flags_notifier.dart';
 import 'package:didpay/features/payment/payment_amount_page.dart';
@@ -58,8 +59,10 @@ class SendPage extends HookConsumerWidget {
                                 transactionType: TransactionType.send,
                                 paymentDetailsState: PaymentDetailsState(
                                   paymentName: recipientDap.dap,
-                                  moneyAddresses: moneyAddresses,
                                 ),
+                              ),
+                              dapState: DapState(
+                                moneyAddresses: moneyAddresses,
                               ),
                             ),
                             fullscreenDialog: true,

--- a/lib/shared/json_schema_form.dart
+++ b/lib/shared/json_schema_form.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:didpay/features/dap/dap_state.dart';
 import 'package:didpay/features/payment/payment_details_state.dart';
 import 'package:didpay/shared/next_button.dart';
 import 'package:didpay/shared/theme/grid.dart';
@@ -11,12 +12,14 @@ import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 class JsonSchemaForm extends HookWidget {
   final PaymentDetailsState state;
   final Future<void> Function(Map<String, String>) onSubmit;
+  final DapState? dapState;
 
   final _formKey = GlobalKey<FormState>();
 
   JsonSchemaForm({
     required this.state,
     required this.onSubmit,
+    this.dapState,
     super.key,
   });
 
@@ -58,9 +61,13 @@ class JsonSchemaForm extends HookWidget {
             final pattern = valueMap['pattern'] as String?;
 
             final formatter = TextInputUtil.getMaskFormatter(pattern);
-            final initialText = state.formData?[key] ??
-                state.moneyAddresses?.firstOrNull?.css.split(':').lastOrNull ??
+
+            final dapPrefillText = (key == 'chain'
+                    ? dapState?.protocol
+                    : dapState?.paymentAddress) ??
                 '';
+
+            final initialText = state.formData?[key] ?? dapPrefillText;
             final controller = TextEditingController(text: initialText);
 
             final focusNode = FocusNode();

--- a/test/features/home/home_page_test.dart
+++ b/test/features/home/home_page_test.dart
@@ -47,7 +47,7 @@ void main() async {
       when(
         () => mockTbdexService.getOfferings(
           pfis,
-          payinCurrency: 'USDC',
+          payinCurrencies: ['USDC'],
         ),
       ).thenAnswer((_) async => offerings);
 

--- a/test/features/payment/payment_amount_page_test.dart
+++ b/test/features/payment/payment_amount_page_test.dart
@@ -32,7 +32,6 @@ void main() async {
     when(
       () => mockTbdexService.getOfferings(
         pfis,
-        payoutCurrency: 'USDC',
       ),
     ).thenAnswer((_) async => offerings);
   });


### PR DESCRIPTION
this pr adds a `DapState` which is used to support finding offerings specific to a dap's available money addresses and to autofill payment details based on the selected currency and associated money address.