### PR TITLE
fix: change filter to look for `USD_STOREDBAL_PAYIN`

### DIFF
--- a/lib/features/tbdex/tbdex_service.dart
+++ b/lib/features/tbdex/tbdex_service.dart
@@ -61,7 +61,7 @@ class TbdexService {
             .where(
               (offering) =>
                   offering.data.payin.methods.firstOrNull?.kind !=
-                  'STORED_BALANCE',
+                  'USD_STOREDBAL_PAYIN',
             )
             .toList(),
       ),


### PR DESCRIPTION
this pr updates the temporary offerings filter on stored balance payin kinds to filter out `USD_STOREDBAL_PAYIN` instead of `STORED_BALANCE`