### PR TITLE
fix: reset quote async value

### DIFF
--- a/lib/features/payment/payment_details_page.dart
+++ b/lib/features/payment/payment_details_page.dart
@@ -162,7 +162,10 @@ class PaymentDetailsPage extends HookConsumerWidget {
                   ),
                 );
 
-                if (issuedCredential == null) return;
+                if (issuedCredential == null) {
+                  quote.value = null;
+                  return;
+                }
 
                 credentials = [issuedCredential as String];
               }


### PR DESCRIPTION
- this pr resets the quote `AsyncValue` in `PaymentDetailsPage` after exiting kcc flow without getting an issued credential