### PR TITLE
chore: remove 'verifying dap...' loading message from sendpage

### DIFF
--- a/lib/features/dap/dap_form.dart
+++ b/lib/features/dap/dap_form.dart
@@ -53,35 +53,51 @@ class DapForm extends HookConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  TextFormField(
-                    focusNode: focusNode,
-                    controller: textController,
-                    onTap: () => errorText.value = null,
-                    onTapOutside: (_) {
-                      if (textController.text.isNotEmpty) {
-                        _parseDap(
-                          textController.text,
-                          errorMessage,
-                          errorText,
-                        );
-                      }
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          focusNode: focusNode,
+                          controller: textController,
+                          onTap: () => errorText.value = null,
+                          onTapOutside: (_) {
+                            if (textController.text.isNotEmpty) {
+                              _parseDap(
+                                textController.text,
+                                errorMessage,
+                                errorText,
+                              );
+                            }
 
-                      focusNode.unfocus();
-                    },
-                    onFieldSubmitted: (_) => _parseDap(
-                      textController.text,
-                      errorMessage,
-                      errorText,
-                    ),
-                    enableSuggestions: false,
-                    autocorrect: false,
-                    decoration: InputDecoration(
-                      labelText: Loc.of(context).dapHint,
-                      errorText: errorText.value,
-                    ),
-                    validator: (value) => value == null || value.isEmpty
-                        ? Loc.of(context).thisFieldCannotBeEmpty
-                        : null,
+                            focusNode.unfocus();
+                          },
+                          onFieldSubmitted: (_) => _parseDap(
+                            textController.text,
+                            errorMessage,
+                            errorText,
+                          ),
+                          enableSuggestions: false,
+                          autocorrect: false,
+                          decoration: InputDecoration(
+                            labelText: Loc.of(context).dapHint,
+                            errorText: errorText.value,
+                          ),
+                          validator: (value) => value == null || value.isEmpty
+                              ? Loc.of(context).thisFieldCannotBeEmpty
+                              : null,
+                        ),
+                      ),
+                      const SizedBox(width: Grid.xs),
+                      if (dap.value?.isLoading ?? false)
+                        const Padding(
+                          padding: EdgeInsets.all(Grid.xxs),
+                          child: SizedBox.square(
+                            dimension: Grid.sm,
+                            child: CircularProgressIndicator(),
+                          ),
+                        ),
+                    ],
                   ),
                 ],
               ),

--- a/lib/features/send/send_page.dart
+++ b/lib/features/send/send_page.dart
@@ -29,52 +29,48 @@ class SendPage extends HookConsumerWidget {
     return Scaffold(
       appBar: _buildAppBar(context, featureFlags),
       body: SafeArea(
-        child: dap.value != null
-            ? dap.value!.when(
-                data: (_) => Container(),
-                loading: () =>
-                    LoadingMessage(message: Loc.of(context).verifyingDap),
-                error: (error, _) => ErrorMessage(
-                  message: error.toString(),
-                  onRetry: () => dap.value = null,
+        child: switch (dap.value) {
+          AsyncError(:final error) => ErrorMessage(
+              message: error.toString(),
+              onRetry: () => dap.value = null,
+            ),
+          _ => Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Header(
+                  title: Loc.of(context).whoDoYouWantToPay,
+                  subtitle: Loc.of(context).enterADap,
                 ),
-              )
-            : Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Header(
-                    title: Loc.of(context).whoDoYouWantToPay,
-                    subtitle: Loc.of(context).enterADap,
-                  ),
-                  Expanded(
-                    child: DapForm(
-                      buttonTitle: Loc.of(context).next,
-                      dapText: dapText,
-                      dap: dap,
-                      onSubmit: (recipientDap, moneyAddresses) async {
-                        await Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => PaymentAmountPage(
-                              paymentState: PaymentState(
-                                transactionType: TransactionType.send,
-                                paymentDetailsState: PaymentDetailsState(
-                                  paymentName: recipientDap.dap,
-                                ),
-                              ),
-                              dapState: DapState(
-                                moneyAddresses: moneyAddresses,
+                Expanded(
+                  child: DapForm(
+                    buttonTitle: Loc.of(context).next,
+                    dapText: dapText,
+                    dap: dap,
+                    onSubmit: (recipientDap, moneyAddresses) async {
+                      await Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => PaymentAmountPage(
+                            paymentState: PaymentState(
+                              transactionType: TransactionType.send,
+                              paymentDetailsState: PaymentDetailsState(
+                                paymentName: recipientDap.dap,
                               ),
                             ),
-                            fullscreenDialog: true,
+                            dapState: DapState(
+                              moneyAddresses: moneyAddresses,
+                            ),
                           ),
-                        );
+                          fullscreenDialog: true,
+                        ),
+                      );
 
-                        if (context.mounted) dap.value = null;
-                      },
-                    ),
+                      if (context.mounted) dap.value = null;
+                    },
                   ),
-                ],
-              ),
+                ),
+              ],
+            ),
+        },
       ),
     );
   }


### PR DESCRIPTION
This PR updates the `SendPage` to remove the "Verifying DAP..." loading message and show a loading spinner to the right of the DAP input form when resolving the DAP.

https://github.com/user-attachments/assets/fd701818-8ca4-4abf-af3e-ae4917d7a695

Closes #285

