### PR TITLE
fix(web): prevent unsupported operation error in isPhysicalDevice() on web

### DIFF
--- a/lib/features/device/device_info_service.dart
+++ b/lib/features/device/device_info_service.dart
@@ -1,6 +1,7 @@
-import 'dart:io';
+import 'dart:io' show Platform;
 
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 final deviceInfoServiceProvider = Provider((ref) => DeviceInfoService());
@@ -8,7 +9,18 @@ final deviceInfoServiceProvider = Provider((ref) => DeviceInfoService());
 class DeviceInfoService {
   final _deviceInfo = DeviceInfoPlugin();
 
-  Future<bool> isPhysicalDevice() async => Platform.isIOS
-      ? (await _deviceInfo.iosInfo).isPhysicalDevice
-      : Platform.isAndroid && (await _deviceInfo.androidInfo).isPhysicalDevice;
+  Future<bool> isPhysicalDevice() async {
+    if (kIsWeb) {
+      // On web, return false as there is no physical device
+      return false;
+    }
+    if (Platform.isIOS) {
+      return (await _deviceInfo.iosInfo).isPhysicalDevice;
+    }
+    if (Platform.isAndroid) {
+      return (await _deviceInfo.androidInfo).isPhysicalDevice;
+    }
+    // Default return for unsupported platforms
+    return false;
+  }
 }


### PR DESCRIPTION

Added a check for kIsWeb in the DeviceInfoService to bypass the `isPhysicalDevice()` check on web platforms, since the app doesn't support QR code scanning on the web. Now the method will return false when running on the web, avoiding the unsupported operation error that occurs when trying to run device checks.

- Imported `kIsWeb` to detect web platform.
- Updated isPhysicalDevice() to return false for the web platform.
- Ensured backward compatibility with iOS and Android platforms.