### PR TITLE
chore: update `TestData`

### DIFF
--- a/test/helpers/test_data.dart
+++ b/test/helpers/test_data.dart
@@ -27,9 +27,9 @@ class TestData {
   static FeatureFlag getFeatureFlag(String name, String description) =>
       FeatureFlag(name: name, description: description);
 
-  static Map<Pfi, List<Offering>> getOfferingsMap(
+  static Map<Pfi, List<Offering>> getOfferingsMap({
     List<String>? payoutCurrencies,
-  ) =>
+  }) =>
       {
         Pfi(did: pfiDid.uri):
             (payoutCurrencies != null && payoutCurrencies.isNotEmpty)

--- a/test/helpers/test_data.dart
+++ b/test/helpers/test_data.dart
@@ -27,8 +27,16 @@ class TestData {
   static FeatureFlag getFeatureFlag(String name, String description) =>
       FeatureFlag(name: name, description: description);
 
-  static Map<Pfi, List<Offering>> getOfferingsMap() => {
-        Pfi(did: pfiDid.uri): [getOffering()],
+  static Map<Pfi, List<Offering>> getOfferingsMap(
+    List<String>? payoutCurrencies,
+  ) =>
+      {
+        Pfi(did: pfiDid.uri):
+            (payoutCurrencies != null && payoutCurrencies.isNotEmpty)
+                ? payoutCurrencies
+                    .map((currency) => getOffering(payoutCurrency: currency))
+                    .toList()
+                : [getOffering()],
       };
 
   static List<Pfi> getPfis() => [Pfi(did: pfiDid.uri)];
@@ -37,6 +45,7 @@ class TestData {
       AccountBalance(total: '101', currencyCode: 'USD', balancesMap: {});
 
   static Offering getOffering({
+    String? payoutCurrency,
     PresentationDefinition? requiredClaims,
     List<PayinMethod>? payinMethods,
     List<PayoutMethod>? payoutMethods,
@@ -59,7 +68,7 @@ class TestData {
                 ],
           ),
           payout: PayoutDetails(
-            currencyCode: 'USD',
+            currencyCode: payoutCurrency ?? 'USD',
             methods: payoutMethods ??
                 [
                   PayoutMethod(


### PR DESCRIPTION
this pr adds `payoutCurrency` and `payoutCurrencies` as optional named parameters to the `TestData` methods `getOffering()` and `getOfferingsMap()`, respectively 