### PR TITLE
test: add tests for `TransactionNotifier`

### DIFF
--- a/test/features/transaction/transaction_notifier_test.dart
+++ b/test/features/transaction/transaction_notifier_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:didpay/features/did/did_provider.dart';
+import 'package:didpay/features/tbdex/tbdex_service.dart';
+import 'package:didpay/features/transaction/transaction.dart';
+import 'package:didpay/features/transaction/transaction_notifier.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../helpers/mocks.dart';
+import '../../helpers/riverpod_helpers.dart';
+import '../../helpers/test_data.dart';
+
+class Listener<T> extends Mock {
+  void call(T? previous, T next);
+}
+
+void main() async {
+  await TestData.initializeDids();
+
+  setUpAll(() {
+    registerFallbackValue(
+      const AsyncData<Transaction?>(null),
+    );
+  });
+
+  group('TransactionNotifier', () {
+    final pfi = TestData.getPfi('did:dht:pfiDid');
+    const exchangeId = 'rfq_01ha835rhefwmagsknrrhvaa0k';
+    final parameters = TransactionProviderParameters(pfi, exchangeId);
+
+    final did = TestData.aliceDid;
+
+    test('should set the state to AsyncValue.data(transaction) on read',
+        () async {
+      final mockTbdexService = MockTbdexService();
+      final exchange = TestData.getExchange();
+
+      when(
+        () => mockTbdexService.getExchange(
+          did,
+          pfi.did,
+          exchangeId,
+        ),
+      ).thenAnswer((_) async => exchange);
+
+      final container = createContainer(
+        overrides: [
+          didProvider.overrideWith(
+            (ref) => did,
+          ),
+          tbdexServiceProvider.overrideWith(
+            (ref) => mockTbdexService,
+          ),
+        ],
+      );
+
+      final listener = Listener<AsyncValue<void>>();
+
+      final transactionProviderListenable = transactionProvider(parameters);
+
+      container.listen(transactionProviderListenable, listener.call);
+
+      await container.read(transactionProviderListenable.future);
+
+      verify(
+        () => listener(
+          const AsyncLoading<Transaction?>(),
+          any(that: isA<AsyncData<Transaction?>>()),
+        ),
+      );
+    });
+
+    test('should set the state to AsyncValue.error when error occurs',
+        () async {
+      final mockTbdexService = MockTbdexService();
+
+      when(
+        () => mockTbdexService.getExchange(
+          did,
+          pfi.did,
+          exchangeId,
+        ),
+      ).thenThrow(Exception('Error fetching exchange'));
+
+      final container = createContainer(
+        overrides: [
+          didProvider.overrideWith(
+            (ref) => did,
+          ),
+          tbdexServiceProvider.overrideWith(
+            (ref) => mockTbdexService,
+          ),
+        ],
+      );
+
+      final listener = Listener<AsyncValue<void>>();
+
+      final transactionProviderListenable = transactionProvider(parameters);
+
+      container.listen(transactionProviderListenable, listener.call);
+
+      unawaited(await container.read(transactionProviderListenable.future));
+
+      verify(
+        () => listener(
+          any(that: isA<AsyncError>()),
+          const AsyncData<Transaction?>(null),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/transaction/transaction_notifier_test.dart
+++ b/test/features/transaction/transaction_notifier_test.dart
@@ -15,6 +15,11 @@ import '../../helpers/test_data.dart';
 void main() async {
   await TestData.initializeDids();
 
+  final pfi = TestData.getPfi('did:dht:pfiDid');
+  const exchangeId = 'rfq_01ha835rhefwmagsknrrhvaa0k';
+  final parameters = TransactionProviderParameters(pfi, exchangeId);
+  final did = TestData.aliceDid;
+
   setUpAll(() {
     registerFallbackValue(
       const AsyncData<Transaction?>(null),
@@ -22,12 +27,6 @@ void main() async {
   });
 
   group('TransactionNotifier', () {
-    final pfi = TestData.getPfi('did:dht:pfiDid');
-    const exchangeId = 'rfq_01ha835rhefwmagsknrrhvaa0k';
-    final parameters = TransactionProviderParameters(pfi, exchangeId);
-
-    final did = TestData.aliceDid;
-
     test('should set the state to AsyncValue.data(transaction) on read',
         () async {
       final mockTbdexService = MockTbdexService();

--- a/test/features/transaction/transaction_notifier_test.dart
+++ b/test/features/transaction/transaction_notifier_test.dart
@@ -12,10 +12,6 @@ import '../../helpers/mocks.dart';
 import '../../helpers/riverpod_helpers.dart';
 import '../../helpers/test_data.dart';
 
-class Listener<T> extends Mock {
-  void call(T? previous, T next);
-}
-
 void main() async {
   await TestData.initializeDids();
 

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -79,3 +79,7 @@ class MockAccountBalanceNotifier
   @override
   FutureOr<AccountBalance?> build() async => accountBalance;
 }
+
+class Listener<T> extends Mock {
+  void call(T? previous, T next);
+}


### PR DESCRIPTION
This PR adds UI tests for the `TransactionNotifier` class.

Closes #291.